### PR TITLE
Spectator Improvements

### DIFF
--- a/addons/spectator/XEH_postInit.sqf
+++ b/addons/spectator/XEH_postInit.sqf
@@ -10,6 +10,33 @@ if (isServer) then {
     GVAR(radioChannel) = radioChannelCreate [[0.96, 0.34, 0.13, 0.8],"Spectator Chat","[SPECTATOR] %UNIT_NAME",[]];
     publicVariable QGVAR(radioChannel);
 
+    createCenter sideLogic;
     GVAR(group) = createGroup sideLogic;
+
+    if (isNull GVAR(group)) then {
+        createCenter civilian;
+        GVAR(group) = createGroup civilian;
+    };
+
     publicVariable QGVAR(group);
+
+    // Clean up disconnected spectator units.
+    private _spectator_disconnect_eh = addMissionEventHandler ["HandleDisconnect",{
+        params ["unit"];
+        if (_unit isKindOf QGVAR(unit)) then { deleteVehicle _unit; };
+        false;
+    }];
+};
+
+if (hasInterface) then {
+    // Hide ST HUD if spectator is OPEN
+    if (isClass (configfile >> "CfgPatches" >> "STUI_GroupHUD")) then {
+        [{!isNil "STUI_Canvas_ShownHUD"}, {
+            STUI_Canvas_ShownHUD_old = STUI_Canvas_ShownHUD;
+            STUI_Canvas_ShownHUD = {
+                if !(call STUI_Canvas_ShownHUD_old) exitWith {false};
+                !(call FUNC(isOpen));
+            };
+        }, []] call CBA_fnc_waitUntilAndExecute;
+    };
 };

--- a/addons/spectator/functions/fn_init.sqf
+++ b/addons/spectator/functions/fn_init.sqf
@@ -30,6 +30,19 @@ if(isNil QGVAR(unit)) then {GVAR(unit) = objNull};
 
 // Create a Virtual Agent to act as our player to make sure we get to keep Draw3D
 if(isNull GVAR(unit) || !(typeOf GVAR(unit) isEqualTo QGVAR(unit))) then {
+
+    if (isNull GVAR(group)) then { /* Incase spectator group is null */
+        createCenter sideLogic;
+        GVAR(group) = createGroup sideLogic;
+
+        if (isNull GVAR(group)) then {
+            createCenter civilian;
+            GVAR(group) = createGroup civilian;
+        };
+
+        publicVariable QGVAR(group);
+    };
+
     private _newUnit = (GVAR(group)) createUnit [QGVAR(unit), [0,0,5], [], 0, "FORM"];
     if (isNull _newUnit) then {
         // Unable to create new unit - Usually if too many groups for sideLogic exist.

--- a/addons/spectator/functions/fn_keyhandler.sqf
+++ b/addons/spectator/functions/fn_keyhandler.sqf
@@ -237,15 +237,24 @@ switch true do {
     _done = false;
   };
   case (_key in (actionKeys "curatorInterface") && _type == KEYDOWN): {
-    if(!isnull getAssignedCuratorLogic player) then {
-      closeDialog 2;
-      [] spawn {
-          sleep 0.1;
-          openCuratorInterface;
-          waitUntil {sleep 0.1;!isNull (findDisplay 312)}; // wait until open
-          (findDisplay 312) displayAddEventHandler ["Unload",{_this spawn FUNC(zeusUnload);}];
-      };
-    };
+        if(!isNull getAssignedCuratorLogic player) then {
+            private _pos = getPos GVAR(camera);
+            private _vectorUp = vectorUp GVAR(camera);
+            private _vectorDir = vectorDir GVAR(camera);
+            closeDialog 2;
+            [_pos,_vectorUp,_vectorDir] spawn {
+                params ["_pos", "_vectorUp", "_vectorDir"];
+                sleep 0.1;
+                openCuratorInterface;
+                waitUntil {sleep 0.1;!isNull (findDisplay 312)}; // wait until open
+                curatorCamera setPos _pos;
+                curatorCamera setVectorDirAndUp [_vectorDir,_vectorUp];
+                (findDisplay 312) displayAddEventHandler ["Unload",{GVAR(zeusPos) = getPos curatorCamera; GVAR(zeusDir) = getDir curatorCamera; GVAR(zeusPitchBank) = curatorCamera call BIS_fnc_getPitchBank;_this spawn FUNC(zeusUnload);}];
+                sleep 0.5;
+                curatorCamera setPos _pos;
+                curatorCamera setVectorDirAndUp [_vectorDir,_vectorUp];
+            };
+        };
   };
   case default {
       _done =false;

--- a/addons/spectator/functions/fn_onLoad.sqf
+++ b/addons/spectator/functions/fn_onLoad.sqf
@@ -40,13 +40,29 @@ if(!getMissionConfigValue ["TMF_Spectator_AllSides",true]) then {
     GVAR(sides_button_strings) = ["SHOWING YOUR SIDE","NONE"];
 };
 
-private _allowedModes = [getMissionConfigValue ["TMF_Spectator_AllowFollowCam",true],getMissionConfigValue ["TMF_Spectator_AllowFreeCam",true],getMissionConfigValue ["TMF_Spectator_AllowFPCam",true]];
-{
-    if(_x) exitWith {
-        GVAR(mode) = _forEachIndex;
-        [] call FUNC(setTarget);
-    };
-} forEach _allowedModes;
+if (!isNil QGVAR(zeusPos) && {getMissionConfigValue ["TMF_Spectator_AllowFreeCam",true]}) then {
+
+    GVAR(mode) = FREECAM;
+    [] call FUNC(setTarget);
+    //GVAR(zeusPos) = getPos curatorCamera; GVAR(zeusDir) = getDir curatorCamera; GVAR(zeusPitchBank) = curatorCamera call BIS_fnc_getPitchBank;
+
+    private _pitch = GVAR(zeusPitchBank) select 0;
+    GVAR(followcam_angle) = [GVAR(zeusDir),_pitch];
+    GVAR(camera) setPos GVAR(zeusPos);
+    GVAR(camera) setDir GVAR(zeusDir);
+    [GVAR(camera),_pitch,0] call BIS_fnc_setPitchBank;
+    GVAR(camera) camSetFov GVAR(followcam_fov);
+    GVAR(camera) camCommit 0;
+    GVAR(zeusPos) = nil;
+} else {
+    private _allowedModes = [getMissionConfigValue ["TMF_Spectator_AllowFollowCam",true],getMissionConfigValue ["TMF_Spectator_AllowFreeCam",true],getMissionConfigValue ["TMF_Spectator_AllowFPCam",true]];
+    {
+        if(_x) exitWith {
+            GVAR(mode) = _forEachIndex;
+            [] call FUNC(setTarget);
+        };
+    } forEach _allowedModes;
+};
 
 // if ACRE2 is enabled, enable the mute button
 if (isClass(configFile >> "CfgPatches" >> "acre_main")) then {
@@ -57,10 +73,7 @@ if (isClass(configFile >> "CfgPatches" >> "acre_main")) then {
 
     // Add all languages
     if (!isNil "tmf_acre2_languagesTable") then {
-        private _languages = [];
-        {
-            _languages pushBack (_x select 0);
-        } forEach tmf_acre2_languagesTable;
+        private _languages = tmf_acre2_languagesTable apply {_x select 0};
         _languages call acre_api_fnc_babelSetSpokenLanguages;
     };
 }

--- a/addons/spectator/functions/fn_perFrameHandler.sqf
+++ b/addons/spectator/functions/fn_perFrameHandler.sqf
@@ -3,7 +3,7 @@
 
 disableSerialization;
 private _isOpen = [] call FUNC(isOpen);
-if(!_isOpen) exitWith {{ctrlDelete _x} foreach GVAR(controls)};
+if(!_isOpen) exitWith {{ctrlDelete _x} forEach GVAR(controls); GVAR(controls) = [];};
 if(_isOpen) then {[] call TMF_spectator_fnc_handleUnitList};
 
 

--- a/addons/spectator/functions/fn_updateGroupCache.sqf
+++ b/addons/spectator/functions/fn_updateGroupCache.sqf
@@ -18,7 +18,7 @@ if (count _cluster > 0) then {
 };
 
 private _color = (side _grp) call CFUNC(sideToColor);
-_color set [3,0.7];
+//_color set [3,0.7];
 private _isAI = {isPlayer _x || _x in playableUnits } count units _grp <= 0;
 
 private _cache = [time + 0.1 + random 0.45,_avgpos,_color,_isAI];

--- a/addons/spectator/functions/fn_zeusUnload.sqf
+++ b/addons/spectator/functions/fn_zeusUnload.sqf
@@ -5,5 +5,5 @@ if (isNil "bis_fnc_moduleRemoteControl_unit") then {
 } else {
     waitUntil {sleep 0.1;isNil "bis_fnc_moduleRemoteControl_unit"};
     waitUntil {sleep 0.1;!isNull (findDisplay 312)}; // wait until open
-    (findDisplay 312) displayAddEventHandler ["Unload",{_this spawn tmf_spectator_fnc_zeusUnload;}];
+    (findDisplay 312) displayAddEventHandler ["Unload",{GVAR(zeusPos) = getPos curatorCamera; GVAR(zeusDir) = getDir curatorCamera; GVAR(zeusPitchBank) = curatorCamera call BIS_fnc_getPitchBank; _this spawn tmf_spectator_fnc_zeusUnload;}];
 };


### PR DESCRIPTION
*This pull request does the following:*
- Adds to the work in #66 - Adding further redundancy if the spectator group can not be created or the group disappears. Disables the ST HUD while spectator is open.
- Speed improvements to `tmf_spectator_fnc_drawTags` in test case ~8.3ms to 6.26ms (~34 to 39 frames)
- On exiting and opening Zeus the position is kept between Zeus and Spectator.