### PR TITLE
Fix tags for players and disable cinema borders

### DIFF
--- a/addons/spectator/functions/fn_drawTags.sqf
+++ b/addons/spectator/functions/fn_drawTags.sqf
@@ -1,7 +1,7 @@
 #include "\x\tmf\addons\spectator\script_component.hpp"
 if (!([] call FUNC(isOpen))) exitWith {};
 if (GVAR(showMap) || !GVAR(tags)) exitWith {
-    {_x ctrlShow false} foreach GVAR(controls);
+    {_x ctrlShow false} forEach GVAR(controls);
 };
 
 

--- a/addons/spectator/functions/fn_drawTags.sqf
+++ b/addons/spectator/functions/fn_drawTags.sqf
@@ -85,10 +85,10 @@ private _screenSizeY = (0.01 * safezoneW);
 
             _control ctrlShow true;
 
-            private _isAI = isPlayer _x;
+            private _isPlayer = isPlayer _x;
 
-            (_control controlsGroupCtrl 2) ctrlShow (!_isAI && _distToCam <= 300);
-            (_control controlsGroupCtrl 3) ctrlShow (!_isAI && _distToCam <= 150);
+            (_control controlsGroupCtrl 2) ctrlShow (_isPlayer && _distToCam <= 300);
+            (_control controlsGroupCtrl 3) ctrlShow (_isPlayer && _distToCam <= 150);
 
             // Screenpos already has 2 elements
             _control ctrlSetPosition [(_screenPos select 0) - _screenSizeX,(_screenPos select 1) - _screenSizeY];

--- a/addons/spectator/functions/fn_drawTags.sqf
+++ b/addons/spectator/functions/fn_drawTags.sqf
@@ -43,8 +43,8 @@ private _screenSizeY = (0.01 * safezoneW);
     // Only draw the icon if the grp tags are "enabled"
     if (_render) then {
         _control ctrlShow true;
-        (_control controlsGroupCtrl 2) ctrlShow (!_isAI && _distToCam <= 600);
-        (_control controlsGroupCtrl 3) ctrlShow (!_isAI && _distToCam <= 300);
+        (_control controlsGroupCtrl 2) ctrlShow (!_isAI && _distToCam <= 600); // Nametag
+        (_control controlsGroupCtrl 3) ctrlShow (!_isAI && _distToCam <= 300); // Detail
 
         _control ctrlSetPosition [(_screenPos select 0) - _screenSizeX,(_screenPos select 1) - _screenSizeY];
         _control ctrlCommit 0;
@@ -87,8 +87,8 @@ private _screenSizeY = (0.01 * safezoneW);
 
             private _isPlayer = isPlayer _x;
 
-            (_control controlsGroupCtrl 2) ctrlShow (_isPlayer && _distToCam <= 300);
-            (_control controlsGroupCtrl 3) ctrlShow (_isPlayer && _distToCam <= 150);
+            (_control controlsGroupCtrl 2) ctrlShow (_isPlayer && _distToCam <= 300); // NameTag
+            (_control controlsGroupCtrl 3) ctrlShow (_isPlayer && _distToCam <= 150); // Detail
 
             // Screenpos already has 2 elements
             _control ctrlSetPosition [(_screenPos select 0) - _screenSizeX,(_screenPos select 1) - _screenSizeY];

--- a/addons/spectator/functions/fn_escmenuHandler.sqf
+++ b/addons/spectator/functions/fn_escmenuHandler.sqf
@@ -6,7 +6,7 @@ params ["_mode","_args"];
 disableSerialization;
 switch (_mode) do {
     case "onLoad": {
-      if(serverCommandAvailable "#kick" || !isMultiplayer) then {
+      if ([] call tmf_common_fnc_isAdmin) then {
           ["onLoad",[(_args select 0)],"RscDebugConsole"] execVM "A3\ui_f\scripts\gui\RscDebugConsole.sqf";
       }
       else {
@@ -29,7 +29,7 @@ switch (_mode) do {
     };
     case "onUnload" : {
         _args params ["_display"];
-        if (serverCommandAvailable "#kick" || !isMultiplayer) then {
+        if ([] call tmf_common_fnc_isAdmin) then {
             ["onUnload",[(_args select 0)],"RscDebugConsole"] execVM "A3\ui_f\scripts\gui\RscDebugConsole.sqf";
         };
     };

--- a/addons/spectator/functions/fn_handleUnitList.sqf
+++ b/addons/spectator/functions/fn_handleUnitList.sqf
@@ -46,7 +46,7 @@ private _deadGroups = [];
         // Erase all unit entries in the tree.
         for "_i" from 0 to _count do {
             _unitListControl tvDelete [_forEachIndex,0];
-        }
+        };
 
         if(count _units > 0) then {
             //Re-create units

--- a/addons/spectator/functions/fn_handleUnitList.sqf
+++ b/addons/spectator/functions/fn_handleUnitList.sqf
@@ -16,9 +16,11 @@ if(GVAR(clearGroups)) then { /* Used by UI which groups to display */
     GVAR(allunits) = [];
 };
 private _newGroups = [];
-if(!GVAR(playersOnly)) then { _newGroups = (allGroups select {{alive _x && side _x in tmf_spectator_sides} count units _x > 0}) - GVAR(groups); }
-else { _newGroups = (allGroups select {{alive _x && {side _x in tmf_spectator_sides} &&
-{{isPlayer _x || _x in playableUnits} count (units _x) > 0}} count units _x > 0}) - GVAR(groups); };
+if(!GVAR(playersOnly)) then {
+    _newGroups = (allGroups select {side _x in tmf_spectator_sides && {alive _x} count units _x > 0}) - GVAR(groups);
+} else { 
+    _newGroups = (allGroups select {side _x in tmf_spectator_sides && {alive _x && {{isPlayer _x || _x in playableUnits} count (units _x) > 0}} count units _x > 0 }) - GVAR(groups);
+};
 
 // check if any new groups appeard
 if((count _newGroups) > 0) then {
@@ -39,19 +41,18 @@ private _deadGroups = [];
 {
     private _path = [_forEachIndex];
     private _count = _unitListControl tvCount _path;
-    if(_count != {alive _x} count units _x) then {
-        // Delete all units
-        while {_count > 0} do {
+    private _units = (units _x select {alive _x});
+    if(_count != count _units) then {
+        // Erase all unit entries in the tree.
+        for "_i" from 0 to _count do {
             _unitListControl tvDelete [_forEachIndex,0];
-            _count = _unitListControl tvCount _path;
-        };
+        }
 
-        private _units = (units _x select {alive _x});
         if(count _units > 0) then {
             //Re-create units
             {
                 [_x,_path select 0] call FUNC(createUnitNode);
-            } forEach (units _x select {alive _x});
+            } forEach _units;
         } else {
             //Mark group for deletion.
             _deadGroups pushBack [_forEachIndex,_x];

--- a/addons/spectator/functions/fn_init.sqf
+++ b/addons/spectator/functions/fn_init.sqf
@@ -101,7 +101,7 @@ GVAR(grpTagScale) = profileNamespace getVariable [QGVAR(grpTagScale),1.0];
 GVAR(unitTagScale) = profileNamespace getVariable [QGVAR(unitTagScale),1.0];
 
 
-
+showCinemaBorder false;
 GVAR(camera) cameraEffect ["internal","back"];
 
 // Set the location of the track point

--- a/addons/spectator/functions/fn_keyhandler.sqf
+++ b/addons/spectator/functions/fn_keyhandler.sqf
@@ -221,15 +221,21 @@ switch true do {
       _message = "Tracers have been toggled off";
       if(GVAR(tracers)) then {_message = "Tracers have been toggled on"};
   };
-  case (_key == DIK_SPACE && _type == KEYDOWN) : {
-      if(!getMissionConfigValue ["TMF_Spectator_AllowFollowCam",true] || !getMissionConfigValue ["TMF_Spectator_AllowFreeCam",true]) exitWith {}; // camrea mode disabled
-      if(GVAR(mode) == FOLLOWCAM || GVAR(mode) == FIRSTPERSON) then {
+    case (_key == DIK_SPACE && _type == KEYDOWN) : {
+        if(!getMissionConfigValue ["TMF_Spectator_AllowFollowCam",true] || !getMissionConfigValue ["TMF_Spectator_AllowFreeCam",true]) exitWith {}; // camrea mode disabled
+        if(GVAR(mode) == FOLLOWCAM || GVAR(mode) == FIRSTPERSON) then {
+            if (GVAR(mode) == FOLLOWCAM) then {
+                private _pitch = (GVAR(camera) call BIS_fnc_getPitchBank) select 0;
+                GVAR(followcam_angle) = [getDir GVAR(camera),_pitch];
+            };
           GVAR(mode) = FREECAM;
-      }
-      else {
-          GVAR(mode) = 0;
-      };
-  };
+        }
+        else {
+            GVAR(mode) = FOLLOWCAM;
+            private _pitch = (GVAR(camera) call BIS_fnc_getPitchBank) select 0;
+            GVAR(followcam_angle) = [(getDir GVAR(camera) + 180) mod 360,(_pitch+180) mod 360];
+        };
+    };
   case (_key == DIK_U && _type == KEYDOWN) : {
     [] call FUNC(toggleUI);
   };

--- a/addons/spectator/functions/fn_menuHandler.sqf
+++ b/addons/spectator/functions/fn_menuHandler.sqf
@@ -119,7 +119,7 @@ switch (_button) do {
                 _messsage = "SWITCHED TO FOLLOWCAM";
             };
             case (FREECAM): {
-                _tooltip = "SWITCH TO FRISTPERSON";
+                _tooltip = "SWITCH TO FIRST PERSON";
                 _messsage = "SWITCHED TO FREECAM";
             };
             case (FIRSTPERSON): {

--- a/addons/spectator/functions/fn_menuHandler.sqf
+++ b/addons/spectator/functions/fn_menuHandler.sqf
@@ -127,6 +127,18 @@ switch (_button) do {
                 _messsage = "SWITCHED TO FIRST PERSON";
             };
         };
+
+        // Update variables based off previous mode.
+        if (GVAR(mode) == FOLLOWCAM) then {
+            private _pitch = (GVAR(camera) call BIS_fnc_getPitchBank) select 0;
+            GVAR(followcam_angle) = [getDir GVAR(camera),_pitch];
+        };
+        if (GVAR(mode) == FREECAM) then {
+            GVAR(mode) = FOLLOWCAM;
+            private _pitch = (GVAR(camera) call BIS_fnc_getPitchBank) select 0;
+            GVAR(followcam_angle) = [(getDir GVAR(camera) + 180) mod 360,(_pitch+180) mod 360];
+        };
+
         GVAR(mode) = _nextMode;
         [] call FUNC(setTarget);
 

--- a/addons/spectator/functions/fn_perFrameHandler.sqf
+++ b/addons/spectator/functions/fn_perFrameHandler.sqf
@@ -9,15 +9,19 @@ if(_isOpen) then {[] call TMF_spectator_fnc_handleUnitList};
 
 ctrlSetFocus (uiNamespace getVariable QGVAR(unitlist));
 
-
-
-for [{private _end = GVAR(lastControlIndex)+10;private _count = (count GVAR(controls))}, {GVAR(lastControlIndex) < _end && GVAR(lastControlIndex) < _count }, {GVAR(lastControlIndex) = GVAR(lastControlIndex) + 1}] do {
-    private _x  = GVAR(controls) select GVAR(lastControlIndex);
-    private _value = isNull (_x getVariable [QGVAR(attached),objNull]);
-    if(_value) then {ctrlDelete _x};
-    !_value
+// Cleanup - unused controls.
+private _newIdx = ((count GVAR(controls) - 1) min (GVAR(lastControlIndex)+10));
+for "_idx" from GVAR(lastControlIndex) to _newIdx step 1 do {
+    private _x = GVAR(controls) select _idx;
+    if(isNull (_x getVariable [QGVAR(attached),objNull])) then {
+        ctrlDelete _x;
+    };
 };
-if(GVAR(lastControlIndex) >= count GVAR(controls)) then {GVAR(lastControlIndex) = 0;};
+if (GVAR(lastControlIndex) >= (count GVAR(controls) - 1)) then {
+    GVAR(lastControlIndex) = 0;
+} else {
+    GVAR(lastControlIndex) = _newIdx;
+};
 
 
 GVAR(vehicles) = GVAR(vehicles) select {!isNull _x};
@@ -34,9 +38,9 @@ if (!(_dirArray isEqualTo GVAR(lastCompassValue))) then {
     GVAR(lastCompassValue) = _dirArray;
 };
 
-// update something horrible
+// update something horrible (alive also checks for isNull)
 
-if(GVAR(mode) != FREECAM && !isNil QGVAR(target) && {!isNull GVAR(target)} && {alive GVAR(target)} ) then {
+if(GVAR(mode) != FREECAM && !isNil QGVAR(target) && {alive GVAR(target)} ) then {
     (uiNamespace getVariable QGVAR(unitlabel)) ctrlSetText (name GVAR(target));
 } else {
     (uiNamespace getVariable QGVAR(unitlabel)) ctrlSetText "";


### PR DESCRIPTION
- Fix #91
- Smooths transition from freecam to followcam
- Gives all admins (1Tac admin) access to debug console in spectator
- Makes the control garbage collector run 3x faster