### PR TITLE
Address mod options that now use CBA Settings.

### DIFF
--- a/addons/acre2/Cfg3DEN.hpp
+++ b/addons/acre2/Cfg3DEN.hpp
@@ -35,46 +35,6 @@ class Cfg3DEN
                     collapsed = 0; // When 1, the category is collapsed by default
                     class Attributes
                     {
-                        class TMF_ACRE_TerrainLoss
-                        {
-                            property = "TMF_AcreTerrainLoss";
-                            displayName = "ACRE2 Terrain Loss:";
-                            control = "Slider";
-                            //expression = "[_value] call acre_api_fnc_setLossModelScale;";
-                            tooltip = "How much should terrain affect radio signal strength? (0% disables terrain loss completely)";
-                            defaultValue = 1;
-                            condition = "true";
-                        };
-                        class TMF_ACRE_fullDuplex
-                        {
-                            property = "TMF_AcreFullDuplex";
-                            displayName = "ACRE2 Radio Full-duplex:";
-                            control = "Checkbox";
-                            //expression = "[_value] call acre_api_fnc_setFullDuplex;";
-                            tooltip = "Should radios be able to transmit and recieve simultaneously?";
-                            defaultValue = false;
-                            condition = "true";
-                        };
-                        class TMF_ACRE_interfecence
-                        {
-                            property = "TMF_AcreInterference";
-                            displayName = "ACRE2 Radio interference:";
-                            control = "Checkbox";
-                            //expression = "[_value] call acre_api_fnc_setInterference;";
-                            tooltip = "Should radio signals intefer with each other?";
-                            defaultValue = true;
-                            condition = "true";
-                        };
-                        class TMF_ACRE_AI_reveal
-                        {
-                            property = "TMF_AcreAIReveal";
-                            displayName = "ACRE2 AI Reveal:";
-                            control = "Checkbox";
-                            //expression = "[_value] call acre_api_fnc_setRevealToAI;";
-                            tooltip = "Allow AI to hear players talking? This feature will reveal a player's location to nearby AI if they are talking.";
-                            defaultValue = false;
-                            condition = "true";
-                        };
                         class Network_Enabled
                         {
                             property = "TMF_AcreNetworkEnabled";
@@ -105,9 +65,7 @@ class Cfg3DEN
                             defaultValue = "['ACRE_PRC343','ACRE_PRC148']";
                             condition = "true";
                         };
-                        
                     };
-
                 };
                 class TMF_AcreBabelSettings
                 {

--- a/addons/acre2/XEH_postInit.sqf
+++ b/addons/acre2/XEH_postInit.sqf
@@ -19,31 +19,6 @@ if (getMissionConfigValue ['TMF_AcreBabelEnabled',false]) then {
     } forEach (TMF_BabelArray);
 };
 
-// ACRE 2 API functions.
-
-// TODO Allow again
-/*if (getMissionConfigValue ['TMF_AcreTerrainLoss',1] != 1) then {
-    [(getMissionConfigValue ['TMF_AcreTerrainLoss',1])] call acre_api_fnc_setLossModelScale;
-};*/
-
-// OVERRIDE 1TAC
-[0.5] call acre_api_fnc_setLossModelScale;
-[true] call acre_api_fnc_ignoreAntennaDirection;
-
-if (getMissionConfigValue ['TMF_AcreFullDuplex',false]) then {
-    [true] call acre_api_fnc_setFullDuplex;
-};
-if (!(getMissionConfigValue ['TMF_AcreInterference',true])) then {
-    [(getMissionConfigValue ['TMF_AcreInterference',false])] call acre_api_fnc_setInterference;
-};
-if (!getMissionConfigValue ['TMF_AcreAIReveal',false]) then {
-    [false] call acre_api_fnc_setRevealToAI;
-};
-
-
-
-//getMissionConfigValue
-
 /// Parse Radios
 
 if (getMissionConfigValue ['TMF_AcreNetworkEnabled',false]) then {

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -6,15 +6,9 @@ if (isTMF) then {
     enableSaving [false, false]; // Disable mission saving
     enableSentences false; // Mute AI reports?
 
-    STHud_NoSquadBarMode = true;
     if (hasInterface) then {
         [{time > 0},
          {
-            //Remove command bar from HUD.
-            private _showHud = shownHUD;
-            _showHud set [6,false];
-            showHUD _showHud;
-
             // Turn on Weapon Safety.
             if (currentWeapon player != "" && {!isNil "ACE_safemode_fnc_lockSafety"} && {missionNamespace getVariable [QGVAR(weaponSafety),true]}) then {
                 [player, currentWeapon player, currentMuzzle player] call ACE_safemode_fnc_lockSafety;


### PR DESCRIPTION
**What this pull request does:**
 - ACRE2 and ST HUD now use [CBA settings](https://github.com/CBATeam/CBA_A3/wiki/CBA-Settings-System) for setting various options. This pull request removes their handling from TMF with the intent that they are set via CBA settings system. For sever wide settings use a custom addon like this -> https://github.com/Sniperhid/1tac_misc/pull/63
- Removes the following ACRE2 settings from TMF
![acre_settings](https://cloud.githubusercontent.com/assets/7645788/26724850/728ae2b6-4793-11e7-993a-4b3dab56186e.jpg)
- Addresses #69 and #94 
