### PR TITLE
Fix RPT warnings

### DIFF
--- a/addons/ai/modules/waveSpawner.hpp
+++ b/addons/ai/modules/waveSpawner.hpp
@@ -26,7 +26,7 @@ class GVAR(wavespawn) : Module_F {
         // Module specific arguments
         class Delay {
             displayName = "Execution delay";
-            description = "The time in seconds to wait before spawning the first wave"
+            description = "The time in seconds to wait before spawning the first wave";
             typeName = "NUMBER";
             defaultValue = "0";
         }

--- a/addons/spectator/CfgVehicles.hpp
+++ b/addons/spectator/CfgVehicles.hpp
@@ -83,7 +83,7 @@ class CfgVehicles
     class GVAR(unit) : VirtualMan_F {
         author = ADDON;
         scope = 1;
-        scopeCurator = 1,
+        scopeCurator = 1;
         scopeArsenal = 1;
         delete ACE_SelfActions;
         delete ACE_Actions;

--- a/addons/spectator/config.cpp
+++ b/addons/spectator/config.cpp
@@ -57,7 +57,7 @@ class RscTitles {
                 w = 0.50 * safezoneW;
                 h = 0.30 * safezoneH;
                 shadow = 2;
-                font = "RobotoCondensedBold"
+                font = "RobotoCondensedBold";
                 colorText[] = {1,1,1,1};
                 sizeEx = 0.05 * safeZoneW;
                 text = "PRESS ENTER TO RETURN TO SPECTATOR";
@@ -69,7 +69,7 @@ class RscTitles {
                 w = 0.50 * safezoneW;
                 h = 0.30 * safezoneH;
                 shadow = 2;
-                font = "RobotoCondensedBold"
+                font = "RobotoCondensedBold";
                 colorText[] = {1,1,1,1};
                 sizeEx = 0.05 * safeZoneW;
                 text = "Unknown Mission";


### PR DESCRIPTION
```
19:38:50 File x\tmf\addons\ai\modules\waveSpawner.hpp, line 29: '/CfgVehicles/TMF_ai_wavespawn/Arguments/Delay.description': Missing ';' at the end of line
19:38:50 File x\tmf\addons\spectator\CfgVehicles.hpp, line 83: '/CfgVehicles/TMF_spectator_unit.scopeCurator': Missing ';' at the end of line
19:38:50 File x\tmf\addons\spectator\config.cpp, line 59: '/RscTitles/TMF_spectator_escDisplay/controls/Text.font': Missing ';' at the end of line
19:38:50 File x\tmf\addons\spectator\config.cpp, line 71: '/RscTitles/TMF_spectator_escDisplay/controls/MissionHeader.font': Missing ';' at the end of line
```

Fix the warnings in the RPT