### PR TITLE
Fix Hunt Module - Remove Dalek mode AI can now go upstairs.

### DIFF
--- a/addons/ai/functions/fn_hunt.sqf
+++ b/addons/ai/functions/fn_hunt.sqf
@@ -126,7 +126,7 @@ private _oldGroups = [];
             };
 
             if (!isNull _closestTarget) then {
-                _unit doMove (getPos _closestTarget); //doMove
+                _unit doMove (getPosATL _closestTarget); //doMove
             };
 
         } forEach _hunters;


### PR DESCRIPTION
- Allows AI in hunt module to go upstairs. AI path-finding can still be a bit wonky with mission maker placed buildings but this certainly lowers the prospects of some players from camping.