### PR TITLE
Fix slot description renaming where some slots wouldn't show

### DIFF
--- a/addons/common/functions/fn_initDisplayMultiplayerSetup.sqf
+++ b/addons/common/functions/fn_initDisplayMultiplayerSetup.sqf
@@ -8,7 +8,7 @@ private _fn_update_group_names_in_lobby = {
     params ["_display"];
     private _slotListControl = _display displayCtrl 109;
 
-    private _lastCallsign = "";
+    private _lastGroupName = "";
     for "_playerListIdx" from 1 to (lbSize _slotListControl) do {
         private _currentText = _slotListControl lbText 0;
         private _currentValue = _slotListControl lbValue 0;
@@ -31,22 +31,22 @@ private _fn_update_group_names_in_lobby = {
                 private _common = _descriptions select 0;
                 _common = _common select [0,count _common -1]; // Ensure the last word isn't used so every description has at least one word.
                 {
-                    // Ensure common is not more tokens than the present description.
-                    _common resize ((count _x) min (count _common));
+                    // Ensure common is not more tokens than the present description and one less than the current ensures that every slot has at least one word remaining.
+                    _common resize (((count _x)-1) min (count _common));
                     for "_idx2" from 0 to (count _common -1) do {
                         if (_common select _idx2 != _x select _idx2) exitWith { _common resize _idx2;}
                     };
                 } forEach _descriptions;
-                _lastCallsign = _common joinString " ";
+                _lastGroupName = _common joinString " ";
             } else {
-                _lastCallsign = "";
+                _lastGroupName = "";
             };
 
-            if (_lastCallsign != "") then {
-                _currentText = _lastCallsign;
+            if (_lastGroupName != "") then {
+                _currentText = _lastGroupName;
             };
         } else {
-            _currentText = _currentText select [count _lastCallsign];
+            _currentText = _currentText select [count _lastGroupName];
         };
 
         // Add new entry.


### PR DESCRIPTION
Essentially issues would crop up where some slots wouldn't show if a particularly naming method was used. This PR also fully ensures that no slot will have an empty slot description cementing the fix for #129 


**Bugged:**
![20170716102800_1](https://user-images.githubusercontent.com/7645788/28246507-4f6d57c6-6a13-11e7-95fc-ba17da6df6ef.jpg)
**Fixed:**
![20170716103848_1](https://user-images.githubusercontent.com/7645788/28246508-50d6dba0-6a13-11e7-9aa1-0d4e721a8a31.jpg)
