### PR TITLE
Increase time before ORBAT briefing page appears.

### DIFF
--- a/addons/orbat/XEH_postInit.sqf
+++ b/addons/orbat/XEH_postInit.sqf
@@ -103,7 +103,7 @@ FUNC(PFHUpdate) = {
         //Ensure a 0.5 second delay.
         params ["_params"];
         _params params ["_tickTime"];
-        if (diag_tickTime < _tickTime + 0.5) exitWith {};
+        if (diag_tickTime < _tickTime + 1.5) exitWith {};
         
         [_this select 1] call CBA_fnc_removePerFrameHandler; 
         


### PR DESCRIPTION
Sometimes  group names are incorrect on the orbat page. This is because `GroupID` won't return the correct group name. This PR increases the delay in the aim of reducing its occurance.