### PR TITLE
Ensure side of spawned units is correct.

### DIFF
--- a/addons/ai/functions/fn_garrisonQuantity.sqf
+++ b/addons/ai/functions/fn_garrisonQuantity.sqf
@@ -116,6 +116,9 @@ for "_i" from 1 to (_aiNumberToSpawn min _freeBuildingSpaces) do {
         _mkr setMarkerText (_unitClassname);
     };
 };
+
+// Ensure side is corrected -- https://feedback.bistudio.com/T70739.
+private _units = units _mainGroup;
+_units join _mainGroup;
     
-    
-_logic setVariable ["spawned_units",units _mainGroup,true]; // global set variable
+_logic setVariable ["spawned_units",_units,true]; // global set variable

--- a/addons/ai/functions/fn_spawnWave.sqf
+++ b/addons/ai/functions/fn_spawnWave.sqf
@@ -31,6 +31,8 @@ _data = _logic getVariable [QGVAR(waveData), []];
         } forEach _units;
     } forEach _vehicles;
 
+    // Ensure side is corrected -- https://feedback.bistudio.com/T70739.
+    (units _grp) join _grp;
 
     _lastIndex = (count waypoints _grp)-1;
     for "_i" from 0 to ((count _waypoints) - 1) step 1 do {


### PR DESCRIPTION
- The version of `createUnit` we use does not set the side of the unit. Details in this ticket -> https://feedback.bistudio.com/T70739.
- This PR ensures that their side is set correctly. Resolves #166