### PR TITLE
Fix spectator JIP issues.

### DIFF
--- a/addons/spectator/functions/fn_init.sqf
+++ b/addons/spectator/functions/fn_init.sqf
@@ -7,6 +7,9 @@ params ["_unit","_oldUnit",["_forced",false,[false]]];
 
 if(!isNil QGVAR(unit) && {player == GVAR(unit)}) exitWith {createDialog QGVAR(dialog);};
 
+// Wait until mission is loaded properly. Prevents JIP issues.
+waitUntil {!isNull ([] call BIS_fnc_DisplayMission)};
+
 private _isJip = didJIP;
 
 // disable this to instantly switch to the spectator script.


### PR DESCRIPTION
- Addresses #19 
- In short if you JIPed and your unit died whilst JIPing or the unit had switch groups spectator wouldn't load properly because of weird engine behaviour. This fixes it.