### PR TITLE
Fix wave spawner giving extra waypoint.

### DIFF
--- a/addons/ai/functions/fn_spawnWave.sqf
+++ b/addons/ai/functions/fn_spawnWave.sqf
@@ -40,7 +40,7 @@ _data = _logic getVariable [QGVAR(waveData), []];
 
         // TODO fix this shit
 
-        _w = _grp addWaypoint [_way select 1, 0,_i,_way select 0];
+        _w = _grp addWaypoint [_way select 1, 0,(_i+1),_way select 0];
         _w setWaypointType (_way select 2);
         _w setWaypointBehaviour (_way select 3);
         _w setWaypointCombatMode (_way select 4);


### PR DESCRIPTION
- Fix #177
- All groups start with a move waypoint to the spawn location.
- When creating groups/units via script command this first waypoint is [0,0,0]
- When using `createWaypoint` with the index it attempts to insert the waypoint at the specified index. What was occurring was that this [0,0,0] waypoint would be bumped to the end of the array of waypoints as each waypoint was added to the unit. This ensures that the first waypoint is not overriden.