### PR TITLE
Fix safestart briefing display

### DIFF
--- a/addons/safestart/functions/fn_briefingTextLoad.sqf
+++ b/addons/safestart/functions/fn_briefingTextLoad.sqf
@@ -3,58 +3,57 @@
 disableSerialization;
 
 private _control = uiNamespace getVariable ['TMF_safestart_text',controlNull];
+_control ctrlSetText "";
 
-private _logics = (allMissionObjects "TMF_safestart_module");
 
-private _allUnitLogics = _logics select {(_x getVariable ["TMFUnits",-1]) isEqualTo -1};
+0 = [_control] spawn {
+    disableSerialization;
+    params["_control"];
+    waitUntil{!isNull player};
+    private _logics = (allMissionObjects "TMF_safestart_module");
+    private _allUnitLogics = _logics select {(_x getVariable ["TMFUnits",-1]) isEqualTo -1};
 
-if (count _allUnitLogics > 0) then {
-    private _duration = (_allUnitLogics select 0) getVariable ["Duration",120];
-    private _minutes = floor (_duration / 60);
-    private _seconds = floor (_duration - (_minutes * 60));
-    if(_minutes < 10) then {_minutes = "0"+str _minutes }  else {_minutes = str _minutes};
-    if(_seconds < 10) then {_seconds = "0"+str _seconds} else {_seconds = str _seconds};
+    if (count _allUnitLogics > 0) then {
+        private _duration = (_allUnitLogics select 0) getVariable ["Duration",120];
+        private _minutes = floor (_duration / 60);
+        private _seconds = floor (_duration - (_minutes * 60));
+        if(_minutes < 10) then {_minutes = "0"+str _minutes }  else {_minutes = str _minutes};
+        if(_seconds < 10) then {_seconds = "0"+str _seconds} else {_seconds = str _seconds};
 
-    _control ctrlSetText (format ["SAFESTART %1:%2", _minutes,_seconds]);
-
-} else {
-    _control ctrlSetText "";
-    if (count _logics > 0) then {
-        0 = [_control,_logics] spawn {
-            disableSerialization;
-            params["_control","_logics"];
-            waitUntil{!isNull player};
-            {
-                private _logic = _x;
-                private _appliesToMe = false;
-                switch (_logic getVariable ["TMFUnits",-1]) do {
-                    case (0): {
-                        if (player in (synchronizedObjects _logic)) then {
-                            _appliesToMe = true;
-                        };
-                    };
-                    case (1): {
-                        {
-                            if (player in (units _x)) exitWith {_appliesToMe = true;};
-                        } forEach (synchronizedObjects _logic);
-
-                    };
-                    case (2): {
-                        {
-                            if (side player == (side _x)) then {_appliesToMe = true;};
-                        } forEach synchronizedObjects _logic;
+        _control ctrlSetText (format ["SAFESTART %1:%2", _minutes,_seconds]);
+    } else {
+        {
+            private _logic = _x;
+            private _appliesToMe = false;
+            switch (_logic getVariable ["TMFUnits",-1]) do {
+                case (0): {
+                    if (player in (synchronizedObjects _logic)) then {
+                        _appliesToMe = true;
                     };
                 };
-                if (_appliesToMe) exitWith {
-                    private _duration = _logic getVariable ["Duration",120];
-                    private _minutes = floor (_duration / 60);
-                    private _seconds = floor (_duration - (_minutes * 60));
-                    if(_minutes < 10) then {_minutes = "0"+str _minutes }  else {_minutes = str _minutes};
-                    if(_seconds < 10) then {_seconds = "0"+str _seconds} else {_seconds = str _seconds};
-                    _control ctrlSetText (format ["SAFESTART %1:%2", _minutes,_seconds]);
+                case (1): {
+                    {
+                        if (player in (units _x)) exitWith {_appliesToMe = true;};
+                    } forEach (synchronizedObjects _logic);
+
                 };
-            } forEach _logics;
-        };
-    };
+                case (2): {
+                    {
+                        if (side player == (side _x)) then {_appliesToMe = true;};
+                    } forEach synchronizedObjects _logic;
+                };
+            };
+            if (_appliesToMe) exitWith {
+                private _duration = _logic getVariable ["Duration",120];
+                private _minutes = floor (_duration / 60);
+                private _seconds = floor (_duration - (_minutes * 60));
+                if(_minutes < 10) then {_minutes = "0"+str _minutes }  else {_minutes = str _minutes};
+                if(_seconds < 10) then {_seconds = "0"+str _seconds} else {_seconds = str _seconds};
+                _control ctrlSetText (format ["SAFESTART %1:%2", _minutes,_seconds]);
+            };
+        } forEach _logics;
+    };  
 };
+
+
 


### PR DESCRIPTION
- Adds more of a delay of showing the safestart cuontdown in the briefing. As it would sometimes prematurely run the checks and thus not display. Should be sufficient delay to function.
- Fix #183