### PR TITLE
Spectator improvements

### DIFF
--- a/addons/spectator/dialog.hpp
+++ b/addons/spectator/dialog.hpp
@@ -61,7 +61,7 @@ class RscSpectatorShortcutButton : RscPicture {
 
 class tmf_spectator_dialog
 {
-  idd = 5454;
+  idd = DISPLAY_ID;
   movingEnable = 1;
   enableSimulation = 1;
   enableDisplay = 1;

--- a/addons/spectator/functions/fn_createGroupControl.sqf
+++ b/addons/spectator/functions/fn_createGroupControl.sqf
@@ -9,7 +9,7 @@ if (count _avgpos <= 0 || time > _grpTime) then {
 };
 _grpCache params ["_grpTime","_avgpos","_color","_isAI"];
 
-private _control = (findDisplay 5454) ctrlCreate [QGVAR(GroupTag), -1];
+private _control = (uiNamespace getVariable [QGVAR(display),displayNull]) ctrlCreate [QGVAR(GroupTag), -1];
 _control ctrlShow false;
 
 private _twGrpMkr = [_x] call EFUNC(orbat,getGroupMarkerData);

--- a/addons/spectator/functions/fn_createUnitControl.sqf
+++ b/addons/spectator/functions/fn_createUnitControl.sqf
@@ -2,7 +2,8 @@
 params ["_unit"];
 disableSerialization;
 private _color = (side group _unit) call CFUNC(sideToColor);
-private _control = (findDisplay 5454) ctrlCreate [QGVAR(EntityTag), -1];
+
+private _control = (uiNamespace getVariable [QGVAR(display),displayNull]) ctrlCreate [QGVAR(EntityTag), -1];
 
 _control ctrlShow false;
 

--- a/addons/spectator/functions/fn_createUnitNode.sqf
+++ b/addons/spectator/functions/fn_createUnitNode.sqf
@@ -19,8 +19,6 @@ params["_unit","_parentIndex"];
 
 disableSerialization;
 
-GVAR(allunits) pushBackUnique _unit;
-
 private _name = name _unit;
 if ((_unit getVariable ["tmf_list_name",0]) isEqualTo 0) then {
     _unit setVariable ["tmf_list_name",name _unit]

--- a/addons/spectator/functions/fn_createVehicleControl.sqf
+++ b/addons/spectator/functions/fn_createVehicleControl.sqf
@@ -2,7 +2,7 @@
 params ["_veh"];
 disableSerialization;
 private _color = [1,1,1,1];
-private _control = (findDisplay 5454) ctrlCreate [QGVAR(EntityTag), -1];
+private _control = (uiNamespace getVariable [QGVAR(display),displayNull]) ctrlCreate [QGVAR(EntityTag), -1];
 
 _control ctrlShow false;
 

--- a/addons/spectator/functions/fn_drawTags.sqf
+++ b/addons/spectator/functions/fn_drawTags.sqf
@@ -57,47 +57,57 @@ private _screenSizeY = (0.01 * safezoneW);
 
     {
         private _isVeh = !isNull (objectParent _x);
-        private _pos = ([_x] call CFUNC(getPosVisual)) vectorAdd [0,0,3.1];
-        // circumevent the restriction on storing controls in namespace
         private _control = _x getVariable [QGVAR(tagControl), [controlNull]] select 0;
 
-        if (_isVeh && {isNull (((objectParent _x) getVariable [QGVAR(tagControl),[controlNull]]) select 0)}) then {
-            [objectParent _x] call FUNC(createVehicleControl);
+        if (_isVeh) then {
             GVAR(vehicles) pushBackUnique (objectParent _x); // for speed reasons.
-        };
-
-        private _screenPos = worldToScreen _pos;
-        private _distToCam = _pos distance _campos;
-
-        if (alive _x && count _screenPos > 0 && {!_isVeh && _distToCam <= 500}) then {
-            if (isNull _control) then {
-                [_x] call FUNC(createUnitControl);
-                _control = _x getVariable [QGVAR(tagControl), [controlNull]] select 0;
-            };
-            private _unitColor = _color;
-            private _hasFired = _x getVariable [QGVAR(fired), 0];
-            if (_hasFired > 0) then {
-                _unitColor = [0.8,0.8,0.8,1];
-                _x setVariable [QGVAR(fired), _hasFired-1];
-            };
-
-            [_control,"",_unitColor] call FUNC(controlSetPicture);
-
-            _control ctrlShow true;
-
-            private _isPlayer = isPlayer _x;
-
-            (_control controlsGroupCtrl 2) ctrlShow (_isPlayer && _distToCam <= 300); // NameTag
-            (_control controlsGroupCtrl 3) ctrlShow (_isPlayer && _distToCam <= 150); // Detail
-
-            // Screenpos already has 2 elements
-            _control ctrlSetPosition [(_screenPos select 0) - _screenSizeX,(_screenPos select 1) - _screenSizeY];
-
-            _control ctrlCommit 0;
-        } 
-        else {
             _control ctrlShow false;
+        } else {
+            if (alive _x) then {
+                private _pos = ([_x] call CFUNC(getPosVisual)) vectorAdd [0,0,3.1];
+                private _screenPos = worldToScreen _pos;
+                private _distToCam = _pos distance _campos;
+                
+                // circumevent the restriction on storing controls in namespace
+
+                if (count _screenPos > 0 && _distToCam <= 500) then {
+                    if (isNull _control) then {
+                        [_x] call FUNC(createUnitControl);
+                        _control = _x getVariable [QGVAR(tagControl), [controlNull]] select 0;
+                    };
+                    private _unitColor = _color;
+                    private _hasFired = _x getVariable [QGVAR(fired), 0];
+                    if (_hasFired > 0) then {
+                        _unitColor = [0.8,0.8,0.8,1];
+                        _x setVariable [QGVAR(fired), _hasFired-1];
+                    };
+
+                    [_control,"",_unitColor] call FUNC(controlSetPicture);
+
+                    _control ctrlShow true;
+
+                    private _isPlayer = isPlayer _x;
+
+                    (_control controlsGroupCtrl 2) ctrlShow (_isPlayer && _distToCam <= 300); // NameTag
+                    (_control controlsGroupCtrl 3) ctrlShow (_isPlayer && _distToCam <= 150); // Detail
+
+                    // Screenpos already has 2 elements
+                    _control ctrlSetPosition [(_screenPos select 0) - _screenSizeX,(_screenPos select 1) - _screenSizeY];
+
+                    _control ctrlCommit 0;
+                } 
+                else {
+                    _control ctrlShow false;
+                };
+            } else {
+                //Unit is dead.
+                _x setVariable [QGVAR(tagControl), nil];
+                ctrlDelete _control;
+            };
+
         };
+
+        
     } forEach units _x;
 } forEach allGroups;
 

--- a/addons/spectator/functions/fn_handleUnitList.sqf
+++ b/addons/spectator/functions/fn_handleUnitList.sqf
@@ -13,7 +13,6 @@ if(GVAR(clearGroups)) then { /* Used by UI which groups to display */
     // clear everything
     tvClear _unitListControl;
     GVAR(groups) = [];
-    GVAR(allunits) = [];
 };
 private _newGroups = [];
 if(!GVAR(playersOnly)) then {

--- a/addons/spectator/functions/fn_init.sqf
+++ b/addons/spectator/functions/fn_init.sqf
@@ -5,7 +5,18 @@
 if((_this select 2) isEqualType 0) then {_this set [2,false]};
 params ["_unit","_oldUnit",["_forced",false,[false]]];
 
-if(!isNil QGVAR(unit) && {player == GVAR(unit)}) exitWith {createDialog QGVAR(dialog);};
+// On Re-Open purge any old controls (as they will exist on an old display)
+if (!isNil QGVAR(controls)) then {
+    {_x setVariable [QGVAR(tagControl),nil];} forEach allUnits;
+    {_x setVariable [QGVAR(tagControl),nil];} forEach allGroups;
+    {ctrlDelete _x} forEach GVAR(controls);
+    GVAR(controls) = [];
+};
+
+if(!isNil QGVAR(unit) && {player == GVAR(unit)}) exitWith {
+    createDialog QGVAR(dialog);
+
+};
 
 // Wait until mission is loaded properly. Prevents JIP issues.
 waitUntil {!isNull ([] call BIS_fnc_DisplayMission)};
@@ -114,6 +125,7 @@ GVAR(bulletTrails) = false;
 // MAP
 GVAR(showMap) = false;
 
+
 GVAR(controls) = [];
 
 
@@ -144,6 +156,12 @@ GVAR(freeCam) camCommit 0;
 GVAR(camera) camCommit 0;
 // 0 follow cam, 1 freecam, 2 firstperson
 GVAR(mode) = FOLLOWCAM;
+private _allowedModes = [getMissionConfigValue ["TMF_Spectator_AllowFollowCam",true],getMissionConfigValue ["TMF_Spectator_AllowFreeCam",true],getMissionConfigValue ["TMF_Spectator_AllowFPCam",true]];
+{
+    if(_x) exitWith {
+        GVAR(mode) = _forEachIndex;
+    };
+} forEach _allowedModes;
 
 
 // Sides Button
@@ -198,7 +216,6 @@ GVAR(modifiers_keys) = [false,false,false];
 GVAR(tags) = true;
 GVAR(showlines) = false;
 
-GVAR(allunits) = [];
 GVAR(groups) = [];
 GVAR(vehicles) = [];
 GVAR(clearGroups) = false;

--- a/addons/spectator/functions/fn_keyhandler.sqf
+++ b/addons/spectator/functions/fn_keyhandler.sqf
@@ -112,8 +112,10 @@ switch true do {
       closeDialog 0;
       _display = (findDisplay 46) createDisplay (["RscDisplayInterrupt","RscDisplayMPInterrupt"] select isMultiplayer);
       _display displayAddEventHandler  ["Unload", {
-        [player,player,true] call FUNC(init);
-        [QGVAR(black)] call BIS_fnc_blackIn;
+          with missionNamespace do {
+            [player,player,true] call FUNC(init);
+            [QGVAR(black)] call BIS_fnc_blackIn;
+          };
       }];
     };
     _done = true;

--- a/addons/spectator/functions/fn_menuHandler.sqf
+++ b/addons/spectator/functions/fn_menuHandler.sqf
@@ -1,14 +1,4 @@
 
-
-
-
-
-
-
-
-
-
-
 #include "defines.hpp"
 #include "\x\tmf\addons\spectator\script_component.hpp"
 params ["_button","_args"];
@@ -66,19 +56,22 @@ switch (_button) do {
 
     // Tags button
     case "tags" : {
-      GVAR(tags) = !GVAR(tags);
+        GVAR(tags) = !GVAR(tags);
 
 
-      _tooltip = "ENABLE TAGS";
-      _msg = "TAGS DISABLED";
+        private _tooltip = "ENABLE TAGS";
 
-      if(GVAR(tags)) then {
-          _tooltip = "DISABLE TAGS";
-          _msg = "TAGS ENABLED";
-      };
+        if(GVAR(tags)) then {
+            _tooltip = "DISABLE TAGS";
+        } else {
+            // Remove controls.
+            {_x setVariable [QGVAR(tagControl),nil];} forEach allUnits;
+            {_x setVariable [QGVAR(tagControl),nil];} forEach allGroups;
+            {ctrlDelete _x} forEach GVAR(controls);
+            GVAR(controls) = [];
+        };
 
-
-      _control ctrlSetTooltip _tooltip;
+        _control ctrlSetTooltip _tooltip;
     };
     case "mute" : {
       [] call acre_sys_core_fnc_toggleHeadset;

--- a/addons/spectator/functions/fn_onLoad.sqf
+++ b/addons/spectator/functions/fn_onLoad.sqf
@@ -2,6 +2,9 @@ params ["_display"];
 #include "defines.hpp"
 #include "\x\tmf\addons\spectator\script_component.hpp"
 
+GVAR(groups) = [];
+GVAR(vehicles) = [];
+GVAR(unitUpdate) = -1; // Force unit list to update.
 
 with uiNamespace do {
     GVAR(display) = _display;
@@ -34,6 +37,8 @@ with uiNamespace do {
 };
 
 
+
+
 if(!getMissionConfigValue ["TMF_Spectator_AllSides",true]) then {
     GVAR(sides) = [tmf_spectator_entryside];
     GVAR(sides_button_mode) = [[tmf_spectator_entryside],[]];
@@ -55,13 +60,18 @@ if (!isNil QGVAR(zeusPos) && {getMissionConfigValue ["TMF_Spectator_AllowFreeCam
     GVAR(camera) camCommit 0;
     GVAR(zeusPos) = nil;
 } else {
-    private _allowedModes = [getMissionConfigValue ["TMF_Spectator_AllowFollowCam",true],getMissionConfigValue ["TMF_Spectator_AllowFreeCam",true],getMissionConfigValue ["TMF_Spectator_AllowFPCam",true]];
-    {
-        if(_x) exitWith {
-            GVAR(mode) = _forEachIndex;
-            [] call FUNC(setTarget);
-        };
-    } forEach _allowedModes;
+    if (missionNamespace getVariable [QGVAR(mode),-1] isEqualTo - 1) then {
+        private _allowedModes = [getMissionConfigValue ["TMF_Spectator_AllowFollowCam",true],getMissionConfigValue ["TMF_Spectator_AllowFreeCam",true],getMissionConfigValue ["TMF_Spectator_AllowFPCam",true]];
+        {
+            if(_x) exitWith {
+                GVAR(mode) = _forEachIndex;
+                [] call FUNC(setTarget);
+            };
+        } forEach _allowedModes;
+    } else {
+        // use pre-existing GVAR(mode)
+        [] call FUNC(setTarget);
+    };
 };
 
 // if ACRE2 is enabled, enable the mute button


### PR DESCRIPTION
- Tags will now always show on re-opening the escape menu (by creating controls on the present spectator display)
- On returning from escape menu spectator will return to the former camera position/mode.
- Unit list will forcefully refresh immediately after closing escape menu #131 
- Small rewrite of how controls are handled for dead units should fix/help with #178