### PR TITLE
Wait for variables to be sent.

### DIFF
--- a/addons/acre2/XEH_postInit.sqf
+++ b/addons/acre2/XEH_postInit.sqf
@@ -89,6 +89,7 @@ if (hasInterface) then {
     [{
         if (isNull player) exitWith {};
         if (isNil "tmf_acre2_networksCreated") exitWith {}; //Ensure presets are created
+        if (isNil QEGVAR(common,VarSync)) exitWith {}; // Ensure vars are recieved.
         
         [] call FUNC(clientInit);
         [_this select 1] call CBA_fnc_removePerFrameHandler;

--- a/addons/briefing/XEH_postInit.sqf
+++ b/addons/briefing/XEH_postInit.sqf
@@ -16,6 +16,7 @@ GVAR(addLoadoutNotes) = getMissionConfigValue ["TMF_Briefing_Loadout",false];
    // [{
         [{
             if (isNull player) exitWith {};
+            if (isNil QEGVAR(common,VarSync)) exitWith {};
             //if (GVAR(briefingFrame) == 0) exitWith {GVAR(briefingFrame) = 1;};
 
             [player] call FUNC(generateBriefing);

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -49,3 +49,15 @@ if (isTMF) then {
         };
     };
 }, []] call CBA_fnc_waitUntilAndExecute;
+
+
+if (isServer) then {
+    // As group init variables are sent frame after init, wait double frames before sending VarSync.
+    // This should then go to the end of the network traffic queue.
+    [{
+        [{
+            GVAR(VarSync) = true;
+            publicVariable QGVAR(VarSync);
+        }] call CBA_fnc_execNextFrame;
+    }] call CBA_fnc_execNextFrame;
+};

--- a/addons/orbat/XEH_postInit.sqf
+++ b/addons/orbat/XEH_postInit.sqf
@@ -109,6 +109,7 @@ FUNC(PFHUpdate) = {
         
         [{
             if (isNull player) exitWith {};
+            if (isNil QEGVAR(common,VarSync)) exitWith {};
             [_this select 1] call CBA_fnc_removePerFrameHandler;
 
             [player, true] call FUNC(setup);


### PR DESCRIPTION
- Some systems (ACRE2/ORBAT markers) and briefing pages require variables to be sent to clients before they are executed.
- In theory this PR now sends a variable late in the initialization that should be sent last and then makes the clients wait for it. So in theory these variables should be initialized before things continue.
- Should fix #173 and #111 