### PR TITLE
Add Vehicles to ORBAT system.

### DIFF
--- a/addons/common/functions/fn_numToColor.sqf
+++ b/addons/common/functions/fn_numToColor.sqf
@@ -17,8 +17,20 @@ private _color = switch (_number) do {
     case -1: {"#FFFFFF"};
     case 0: {"#1AFF00"};
     case 1: {"#0071FF"};
-    case 2: {"#E8DF06"};
+    case 2: {"#abe806"};
     case 3: {"#06E8B1"};
+    case 4: {"#E84200"};
+    case 5: {"#FF009E"};
+    case 6: {"#4400E8"};
+    case 7: {"#a24b98"};
+    case 8: {"#224726"};
+    case 9: {"#963f3f"};
+    case 10: {"#005046"};
+    case 11: {"#68341F"};
+    case 12: {"#746299"};
+    case 13: {"#996264"};
+    case 14: {"#997C62"};
+    case 15: {"#51FF8D"};
     default {"#FFAB06"};
 };
 // return color

--- a/addons/orbat/Cfg3DEN.hpp
+++ b/addons/orbat/Cfg3DEN.hpp
@@ -157,13 +157,14 @@ class ctrlListNBox;// : ctrlDefaultText;
 class ctrlTree;// : ctrlDefaultText;
 class ctrlEdit;// : ctrlDefaultText;
 class ctrlToolBox;// : ctrlDefaultText;
+class ctrlCombo;
 
 class RscButtonMenu;
 class RscText;
 
 class cfgScriptPaths
 {
-    TMF_orbat = "x\tmf\addons\orbat\ui_scripts\";
+    TMF_orbat = "x\tmf\addons\orbat\ui_scripts\"; // " // comment here for Bad parser.
 };
 
 class Cfg3DEN
@@ -288,7 +289,7 @@ class Cfg3DEN
             };
             class TMF_orbat_vehicleCallsign
             {
-                displayName = "TMF: Vehicle Callsign";
+                displayName = "TMF: Vehicle ORBAT";
                 collapsed = 0;
                 class Attributes
                 {
@@ -296,12 +297,43 @@ class Cfg3DEN
                     {
                         property = "TMF_orbat_vehicleCallsign";
                         displayName = "Callsign";
-                        tooltip = "Give vehicle a callsign.";
+                        tooltip = "Give vehicle a callsign to show on briefing screen.";
                         condition = "objectVehicle";
                         control = "Edit";
                         defaultValue = "''";
                         expression = "_this setVariable ['TMF_orbat_vehicleCallsign',_value,true];";
                         wikiType = "[[String]]";
+                    };
+                    class TMF_orbat_team
+                    {
+                        property = "TMF_orbat_team";
+                        displayName = "ORBAT Team";
+                        tooltip = "Which team's ORBAT should this vehicle be apart of.";
+                        condition = "objectVehicle";
+                        control = "TMF_ORBAT_team";
+                        expression = "_this setVariable ['TMF_orbat_team',_value,true];";
+                        defaultValue = "''";
+                        value = "''";
+                        wikiType = "[[String]]";
+                    };
+                    class TMF_groupMarker
+                    {
+                        property = "TMF_groupMarker"; // Unique config property name saved in SQM
+                        control = "twGroupMarker"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+                        unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+                        condition = "objectVehicle"; // Condition for attribute to appear (see the table below)
+                        expression = "_this setVariable ['TMF_groupMarker',_value,true];";//"[_this,['TMF_groupMarker',_value]] remoteExecCall ['setVariable',0,true];" //"_this setVariable ['TMF_groupMarker',_value,true];";
+                        defaultValue = "'[]'";
+                        wikiType = "[[String]]";
+                    };
+                    class TMF_OrbatParent
+                    {
+                        property = "TMF_OrbatParent"; // Unique config property name saved in SQM
+                        control = "None"; // UI control base class displayed in Edit Attributes window, points to Cfg3DEN >> Attributes
+                        unique = 0; // When 1, only one entity of the type can have the value in the mission (used for example for variable names or player control)
+                        condition = "objectVehicle"; // Condition for attribute to appear (see the table below)
+                        expression = "_this setVariable ['TMF_OrbatParent',_value,true];";//"[_this,['TMF_OrbatParent',_value]] remoteExecCall ['setVariable',0,true];"; //_this setVariable ['TMF_OrbatParent',_value,true];";
+                        defaultValue = "-1";
                     };
                 };
             };
@@ -345,13 +377,41 @@ class Cfg3DEN
     class Attributes
     {
         class Toolbox; //class Toolbox: Title
-        
+        class Combo;
         class Default;
         class Title : Default
         {
             class Controls
             {
                 class Title;
+            };
+        };
+        class TMF_ORBAT_team: Combo
+        {
+            onLoad = "uiNamespace setVariable ['AttributeTMF_Orbat_team',(_this select 0) controlsGroupCtrl 100];";
+            attributeLoad = "\
+                _ctrlTeams = _this controlsGroupCtrl 100 ;\
+                [_ctrlTeams,_value] call TMF_orbat_fnc_loadTeams;\
+            ";
+            attributeSave = " _ctrlTeams = _this controlsGroupCtrl 100;\
+                private _output = _ctrlTeams lbData lbCurSel _ctrlTeams; _output";
+            class Controls
+            {
+                class Title: ctrlStatic {
+                    style = 0x01;
+                    x = 0;
+                    w = ATTRIBUTE_TITLE_W * GRID_W;
+                    h = SIZE_M * GRID_H;
+                    colorBackground[] = {0,0,0,0};
+                };
+                class ValueRole: ctrlCombo
+                {
+                    idc = 100;
+                    onLoad = "uiNamespace setVariable ['AttributeTMF_Orbat_team',_this select 0];";
+                    x = ATTRIBUTE_TITLE_W * GRID_W;
+                    w = ATTRIBUTE_CONTENT_W * GRID_W;
+                    h = SIZE_M * GRID_H;
+                };
             };
         };
         class TMF_ORBAT_Renamer : Title
@@ -435,7 +495,7 @@ class Cfg3DEN
             onLoad = "['onLoad',_this,'GroupMarker','TMF_orbat',false] call (uinamespace getvariable 'BIS_fnc_initDisplay');"; // 3rd param is the path PATH\scriptName.sqf
             onUnload = "['onUnload',_this,'GroupMarker','TMF_orbat',false] call (uinamespace getvariable 'BIS_fnc_initDisplay');";
 
-            attributeLoad = "['attributeLoad',_this] call (uinamespace getvariable 'GroupMarker_script');";
+            attributeLoad = "['attributeLoad',_this,_value] call (uinamespace getvariable 'GroupMarker_script');";
             attributeSave = "['attributeSave',_this] call (uinamespace getvariable 'GroupMarker_script');";
 
             h = (16.75+0.45) * SIZE_M * GRID_H;

--- a/addons/orbat/CfgFunctions.hpp
+++ b/addons/orbat/CfgFunctions.hpp
@@ -11,6 +11,7 @@ class cfgFunctions {
             class getGroupMarkerData;
             class findOrbatParent;
             class renameUnitAndGroups;
+            class loadTeams;
         };
     };
 };

--- a/addons/orbat/functions/fn_loadTeams.sqf
+++ b/addons/orbat/functions/fn_loadTeams.sqf
@@ -22,14 +22,14 @@ lbClear _control;
 
 private _orbatSettingsArray = ("TMF_ORBAT_Settings" get3DENMissionAttribute "TMF_ORBATSettings");
 if (_orbatSettingsArray isEqualType "") then {
-	_orbatSettingsArray = call compile _orbatSettingsArray;
+    _orbatSettingsArray = call compile _orbatSettingsArray;
 };
 
 private _usingFactions = true;
 if (count _orbatSettingsArray > 0) then {
-	if ((((_orbatSettingsArray) select 0) select 0) isEqualType 0) then {
-		_usingFactions = false;
-	};
+    if ((((_orbatSettingsArray) select 0) select 0) isEqualType 0) then {
+        _usingFactions = false;
+    };
 };
 
 // Allow not being on the ORBAT.
@@ -39,46 +39,46 @@ _control lbSetData [_index,""];
 private _found = false; // Used to track whether or not an entry has been selected, if not at end select index.
 
 if (_usingFactions) then {
-	private _factions = []; {_factions pushBackUnique (toLower (faction _x));} forEach allUnits;
-	_factions = _factions apply {
-		private _faction = _x;
-		[
-			{toLower (faction _x) == _faction && _x in (playableUnits + [player])} count allUnits,
-			{toLower (faction _x) == _faction} count allUnits,
-			_x
-		]
-	};
-	_factions sort false;
-	{
-		_x params ["_playerCount","_unitCount","_faction"];
-		private _displayName = getText (configfile >> "CfgFactionClasses" >> _faction >> "displayName");
-		_displayName = format ["%1 - [Players: %2 All Units: %3]",_displayName,_playerCount,_unitCount];
-		private _index = _control lbAdd _displayName;
-		private _value = _faction;
-		_control lbSetData [_index,_value];
-		//_control lbSetTooltip [_index, _tooltip];
-		if (_value isEqualTo _attributeValue) then {_control lbSetCurSel _index; _found = true;};
-	} forEach _factions;
+    private _factions = []; {_factions pushBackUnique (toLower (faction _x));} forEach allUnits;
+    _factions = _factions apply {
+        private _faction = _x;
+        [
+            {toLower (faction _x) == _faction && _x in (playableUnits + [player])} count allUnits,
+            {toLower (faction _x) == _faction} count allUnits,
+            _x
+        ]
+    };
+    _factions sort false;
+    {
+        _x params ["_playerCount","_unitCount","_faction"];
+        private _displayName = getText (configfile >> "CfgFactionClasses" >> _faction >> "displayName");
+        _displayName = format ["%1 - [Players: %2 All Units: %3]",_displayName,_playerCount,_unitCount];
+        private _index = _control lbAdd _displayName;
+        private _value = _faction;
+        _control lbSetData [_index,_value];
+        //_control lbSetTooltip [_index, _tooltip];
+        if (_value isEqualTo _attributeValue) then {_control lbSetCurSel _index; _found = true;};
+    } forEach _factions;
 } else {
-	private _sides = [east,west,civilian,independent] apply {
-		private _side = _x;
-		[
-			{side _x == _side && _x in (playableUnits + [player])} count allUnits,
-			{side _x == _side} count allUnits,
-			_side
-		]
-	};
-	_sides sort false;
-	{
-		_x params ["_playerCount","_unitCount","_side"];
-		private _displayName = _side call EFUNC(common,sideToString);
-		_displayName = format ["%1 - [Players: %2 All Units: %3]",_displayName,_playerCount,_unitCount];
-		private _index = _control lbAdd _displayName;
-		private _value = str (_side call EFUNC(common,sideToNum));
-		_control lbSetData [_index,_value];
-		//_control lbSetTooltip [_index, _tooltip];
-		if (_value isEqualTo _attributeValue) then {_control lbSetCurSel _index; _found = true;};
-	} forEach _sides;
+    private _sides = [east,west,civilian,independent] apply {
+        private _side = _x;
+        [
+            {side _x == _side && _x in (playableUnits + [player])} count allUnits,
+            {side _x == _side} count allUnits,
+            _side
+        ]
+    };
+    _sides sort false;
+    {
+        _x params ["_playerCount","_unitCount","_side"];
+        private _displayName = _side call EFUNC(common,sideToString);
+        _displayName = format ["%1 - [Players: %2 All Units: %3]",_displayName,_playerCount,_unitCount];
+        private _index = _control lbAdd _displayName;
+        private _value = str (_side call EFUNC(common,sideToNum));
+        _control lbSetData [_index,_value];
+        //_control lbSetTooltip [_index, _tooltip];
+        if (_value isEqualTo _attributeValue) then {_control lbSetCurSel _index; _found = true;};
+    } forEach _sides;
 };
 
 if (!_found and (lbSize _control > 0)) then {

--- a/addons/orbat/functions/fn_loadTeams.sqf
+++ b/addons/orbat/functions/fn_loadTeams.sqf
@@ -1,0 +1,87 @@
+/*
+ * Name = TMF_orbat_fnc_loadTeams
+ * Author = Snippers
+ *
+ * Arguments:
+ * UI function do not use
+ *
+ * Return:
+ * UI function do not use
+ *
+ * Description:
+ * UI function do not use
+ */
+#include "\x\tmf\addons\orbat\script_component.hpp"
+
+disableSerialization;
+params ["_control",["_attributeValue",""]];
+
+// Clear control
+lbClear _control;
+
+
+private _orbatSettingsArray = ("TMF_ORBAT_Settings" get3DENMissionAttribute "TMF_ORBATSettings");
+if (_orbatSettingsArray isEqualType "") then {
+	_orbatSettingsArray = call compile _orbatSettingsArray;
+};
+
+private _usingFactions = true;
+if (count _orbatSettingsArray > 0) then {
+	if ((((_orbatSettingsArray) select 0) select 0) isEqualType 0) then {
+		_usingFactions = false;
+	};
+};
+
+// Allow not being on the ORBAT.
+private _index = _control lbAdd "None";
+_control lbSetData [_index,""];
+
+private _found = false; // Used to track whether or not an entry has been selected, if not at end select index.
+
+if (_usingFactions) then {
+	private _factions = []; {_factions pushBackUnique (toLower (faction _x));} forEach allUnits;
+	_factions = _factions apply {
+		private _faction = _x;
+		[
+			{toLower (faction _x) == _faction && _x in (playableUnits + [player])} count allUnits,
+			{toLower (faction _x) == _faction} count allUnits,
+			_x
+		]
+	};
+	_factions sort false;
+	{
+		_x params ["_playerCount","_unitCount","_faction"];
+		private _displayName = getText (configfile >> "CfgFactionClasses" >> _faction >> "displayName");
+		_displayName = format ["%1 - [Players: %2 All Units: %3]",_displayName,_playerCount,_unitCount];
+		private _index = _control lbAdd _displayName;
+		private _value = _faction;
+		_control lbSetData [_index,_value];
+		//_control lbSetTooltip [_index, _tooltip];
+		if (_value isEqualTo _attributeValue) then {_control lbSetCurSel _index; _found = true;};
+	} forEach _factions;
+} else {
+	private _sides = [east,west,civilian,independent] apply {
+		private _side = _x;
+		[
+			{side _x == _side && _x in (playableUnits + [player])} count allUnits,
+			{side _x == _side} count allUnits,
+			_side
+		]
+	};
+	_sides sort false;
+	{
+		_x params ["_playerCount","_unitCount","_side"];
+		private _displayName = _side call EFUNC(common,sideToString);
+		_displayName = format ["%1 - [Players: %2 All Units: %3]",_displayName,_playerCount,_unitCount];
+		private _index = _control lbAdd _displayName;
+		private _value = str (_side call EFUNC(common,sideToNum));
+		_control lbSetData [_index,_value];
+		//_control lbSetTooltip [_index, _tooltip];
+		if (_value isEqualTo _attributeValue) then {_control lbSetCurSel _index; _found = true;};
+	} forEach _sides;
+};
+
+if (!_found and (lbSize _control > 0)) then {
+    _control lbSetCurSel 0; // set to first element.
+};
+////////////////////////////

--- a/addons/orbat/ui_scripts/GroupMarker.sqf
+++ b/addons/orbat/ui_scripts/GroupMarker.sqf
@@ -1,4 +1,4 @@
-params ["_mode",["_params",[]]];
+params ["_mode",["_params",[]],["_value","[]"]];
 
 // with uiNameSpace do { RadioChannels_script = compile preprocessFileLineNumbers "RadioChannels.sqf"; };  with uiNameSpace do { BabelSettings_script = compile preprocessFileLineNumbers "BabelSettings.sqf"; };  with uiNameSpace do { AcreAddRadioActions_script = compile preprocessFileLineNumbers "AcreAddRadioActions.sqf"; }; with uiNameSpace do { ORBATSettings_script = compile preprocessFileLineNumbers "OrbatSettings.sqf"; }; with uiNameSpace do { GroupMarker_script = compile preprocessFileLineNumbers "GroupMarker.sqf"; };
 
@@ -9,18 +9,19 @@ switch _mode do {
     case "onLoad": {
         private _ctrlGroup = _params select 0;
         GroupMarker_ctrlGroup = _ctrlGroup;
-    
-        private _entity = (get3DENSelected "group") select 0;
-        
+
         _ctrlGroup ctrladdeventhandler ["setfocus",{with uinamespace do {GroupMarker_ctrlGroup = _this select 0;};}];
         _ctrlGroup ctrladdeventhandler ["killfocus",{with uinamespace do {GroupMarker_ctrlGroup = nil;};}];
+    };
+
+    case "attributeLoad": {
+        private _ctrlGroup = _params;
         
-        private _groupMarkerArray = (_entity get3DENAttribute "TMF_groupMarker") select 0;
+        private _groupMarkerArray = _value;
         if (_groupMarkerArray isEqualType "") then {
             _groupMarkerArray = call compile _groupMarkerArray;
         };
-        
-
+        diag_log str ["ORBAT: attrLoad",_params,_ctrlGroup];
         private _ctrlIconToolbox = _ctrlGroup controlsGroupCtrl 100;
         private _ctrlColourToolBox = _ctrlGroup controlsGroupCtrl 101;
         private _ctrlNameEdit = _ctrlGroup controlsGroupCtrl 102;
@@ -52,11 +53,11 @@ switch _mode do {
             };
             _ctrlNameEdit ctrlSetText _mName;
         } else {
-            _ctrlNameEdit ctrlSetText (GroupID _entity);
+            if (count (get3DENSelected "group") > 0) then {
+                private _entity = (get3DENSelected "group") select 0;
+                _ctrlNameEdit ctrlSetText (GroupID _entity);
+            };
         };
-    };
-
-    case "attributeLoad": {
     };
     case "attributeSave": {
         private _ctrlGroup = uiNameSpace getVariable "GroupMarker_ctrlGroup";


### PR DESCRIPTION
- Allows adding vehicles to ORBAT
     - They can have map markers with callsign shown
     - They will show on briefing screen
![image](https://user-images.githubusercontent.com/7645788/34053712-c1d49ad0-e1bf-11e7-83dc-ea07aabf778b.png)

- Vehicles will be given a Vehicle number if no callsign is given. The briefing page now has an indictator of vehicle uniqueness so that it is easy to distinguish if 1 or 2 vehicles of the same type (i.e. M113) are being used by different groups.
![image](https://user-images.githubusercontent.com/7645788/34053673-946d023a-e1bf-11e7-9519-1588083f1b3b.png)


- Vehicles now show a single fraction showing how many seats have been occupied versus total which is clearer to a player (shown above).
- Address #46 

** Changes for mission maker **
- Add Vehicle to ORBAT system (from vehicle attributes):
![image](https://user-images.githubusercontent.com/7645788/34053749-ec27fa98-e1bf-11e7-99dd-765cd32a1189.png)
- Vehicles can be moved around as per other nodes in the ORBAT system
![image](https://user-images.githubusercontent.com/7645788/34053798-15121308-e1c0-11e7-8011-678452fb6d95.png)

