### PR TITLE
Allow setting custom text on the animated mission outro.

### DIFF
--- a/addons/common/CfgEventHandlers.hpp
+++ b/addons/common/CfgEventHandlers.hpp
@@ -42,4 +42,7 @@ class Extended_DisplayLoad_EventHandlers {
     class RscDisplayMultiplayerSetup {
         tmf_slotting = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayMultiplayerSetup)'));
     };
+    class RscDisplayDebriefing {
+        tmf_override_end_text = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayDebriefing)'));
+    };
 };

--- a/addons/common/CfgFunctions.hpp
+++ b/addons/common/CfgFunctions.hpp
@@ -41,6 +41,7 @@ class cfgFunctions {
             class edenHideMapObjects;
             class hideMapObjectsInit;
             class getPosVisual;
+            class initDisplayDebriefing;
             class initDisplayMultiplayerSetup;
             class testGroupsSlottingScreen;
             class secondsToTime;

--- a/addons/common/functions/fn_initDisplayDebriefing.sqf
+++ b/addons/common/functions/fn_initDisplayDebriefing.sqf
@@ -1,0 +1,44 @@
+// Updates the text on the end mission screen.
+
+#include "\x\tmf\addons\common\script_component.hpp"
+disableSerialization;
+params ["_display"];
+
+if (!isNil QGVAR(EndMissionText)) then {
+	[{
+		disableSerialization;
+		params ["_display"];
+		GVAR(EndMissionText) params [["_titleText",""],["_subtitleText",""]];
+		private _titleCtrl = _display displayctrl 20600;
+		private _subtitleCtrl = _display displayctrl 20601;
+		_titleCtrl ctrlsettext toUpper _titleText;
+
+		if (_subtitleText != "") then {
+			if (ctrlText _subtitleCtrl == "") then {
+				// If Hidden we need to emulate the effect.
+				private _subtitlePosFinal = ctrlPosition _subtitleCtrl;
+				private _subtitlePosStart = +_subtitlePosFinal;
+				_subtitlePosStart set [0,(_subtitlePosStart select 0) + (_subtitlePosStart select 2) / 2];
+				_subtitlePosStart set [2,0];
+				_subtitleCtrl ctrlsetposition _subtitlePosStart;
+				_subtitleCtrl ctrlSetFade 0;
+				_subtitleCtrl ctrlcommit 0;
+				_subtitleCtrl ctrlshow false;
+				[_subtitleCtrl,_subtitlePosFinal] spawn {
+					disableSerialization;
+					params ["_subtitleCtrl","_subtitlePosFinal"];
+					sleep 2;
+					_subtitleCtrl ctrlshow true;
+					_subtitleCtrl ctrlsetposition _subtitlePosFinal;
+					_subtitleCtrl ctrlcommit 0.4;
+				};
+			};
+			// Update the text.
+			_subtitleCtrl ctrlSetText toUpper _subtitleText;
+		} else {
+			_subtitleCtrl ctrlSetFade 1;
+			_subtitleCtrl ctrlCommit 0;
+			_subtitleCtrl ctrlshow false;
+		};
+	}, [_display]] call CBA_fnc_execNextFrame;
+};

--- a/addons/common/functions/fn_initDisplayDebriefing.sqf
+++ b/addons/common/functions/fn_initDisplayDebriefing.sqf
@@ -5,40 +5,40 @@ disableSerialization;
 params ["_display"];
 
 if (!isNil QGVAR(EndMissionText)) then {
-	[{
-		disableSerialization;
-		params ["_display"];
-		GVAR(EndMissionText) params [["_titleText",""],["_subtitleText",""]];
-		private _titleCtrl = _display displayctrl 20600;
-		private _subtitleCtrl = _display displayctrl 20601;
-		_titleCtrl ctrlsettext toUpper _titleText;
+    [{
+        disableSerialization;
+        params ["_display"];
+        GVAR(EndMissionText) params [["_titleText",""],["_subtitleText",""]];
+        private _titleCtrl = _display displayctrl 20600;
+        private _subtitleCtrl = _display displayctrl 20601;
+        _titleCtrl ctrlsettext toUpper _titleText;
 
-		if (_subtitleText != "") then {
-			if (ctrlText _subtitleCtrl == "") then {
-				// If Hidden we need to emulate the effect.
-				private _subtitlePosFinal = ctrlPosition _subtitleCtrl;
-				private _subtitlePosStart = +_subtitlePosFinal;
-				_subtitlePosStart set [0,(_subtitlePosStart select 0) + (_subtitlePosStart select 2) / 2];
-				_subtitlePosStart set [2,0];
-				_subtitleCtrl ctrlsetposition _subtitlePosStart;
-				_subtitleCtrl ctrlSetFade 0;
-				_subtitleCtrl ctrlcommit 0;
-				_subtitleCtrl ctrlshow false;
-				[_subtitleCtrl,_subtitlePosFinal] spawn {
-					disableSerialization;
-					params ["_subtitleCtrl","_subtitlePosFinal"];
-					sleep 2;
-					_subtitleCtrl ctrlshow true;
-					_subtitleCtrl ctrlsetposition _subtitlePosFinal;
-					_subtitleCtrl ctrlcommit 0.4;
-				};
-			};
-			// Update the text.
-			_subtitleCtrl ctrlSetText toUpper _subtitleText;
-		} else {
-			_subtitleCtrl ctrlSetFade 1;
-			_subtitleCtrl ctrlCommit 0;
-			_subtitleCtrl ctrlshow false;
-		};
-	}, [_display]] call CBA_fnc_execNextFrame;
+        if (_subtitleText != "") then {
+            if (ctrlText _subtitleCtrl == "") then {
+                // If Hidden we need to emulate the effect.
+                private _subtitlePosFinal = ctrlPosition _subtitleCtrl;
+                private _subtitlePosStart = +_subtitlePosFinal;
+                _subtitlePosStart set [0,(_subtitlePosStart select 0) + (_subtitlePosStart select 2) / 2];
+                _subtitlePosStart set [2,0];
+                _subtitleCtrl ctrlsetposition _subtitlePosStart;
+                _subtitleCtrl ctrlSetFade 0;
+                _subtitleCtrl ctrlcommit 0;
+                _subtitleCtrl ctrlshow false;
+                [_subtitleCtrl,_subtitlePosFinal] spawn {
+                    disableSerialization;
+                    params ["_subtitleCtrl","_subtitlePosFinal"];
+                    sleep 2;
+                    _subtitleCtrl ctrlshow true;
+                    _subtitleCtrl ctrlsetposition _subtitlePosFinal;
+                    _subtitleCtrl ctrlcommit 0.4;
+                };
+            };
+            // Update the text.
+            _subtitleCtrl ctrlSetText toUpper _subtitleText;
+        } else {
+            _subtitleCtrl ctrlSetFade 1;
+            _subtitleCtrl ctrlCommit 0;
+            _subtitleCtrl ctrlshow false;
+        };
+    }, [_display]] call CBA_fnc_execNextFrame;
 };


### PR DESCRIPTION
- Adds ability to override text on the animated end mission page (previously ending text had to be declared in mission config). This will be handy for the TMF admin menu.
- Example:
Execute following code
```sqf
tmf_common_EndMissionText = ["Bear","Powered by Snippers Industries"];
["END1"] spawn BIS_fnc_endMission;
```
Example end mission page:
![image](https://user-images.githubusercontent.com/7645788/34280524-12e02a44-e6b0-11e7-8220-0f3841c45f04.png)

