### PR TITLE
Allow Babel settings to function if not using radio networks

### DIFF
--- a/addons/acre2/XEH_postInit.sqf
+++ b/addons/acre2/XEH_postInit.sqf
@@ -88,12 +88,11 @@ if (_tmfNetworkEnabled) then {
 if (hasInterface) then {
     [{
         if (isNull player) exitWith {};
-        params ["_args"];
-        _args params ["_tmfNetworkEnabled"];
+        params ["_tmfNetworkEnabled"];
         if (_tmfNetworkEnabled && isNil "tmf_acre2_networksCreated") exitWith {}; //Ensure presets are created
         if (isNil QEGVAR(common,VarSync)) exitWith {}; // Ensure vars are recieved.
         
         [] call FUNC(clientInit);
         [_this select 1] call CBA_fnc_removePerFrameHandler;
-    }, 1,[_tmfNetworkEnabled]] call CBA_fnc_addPerFrameHandler;
+    }, 1,_tmfNetworkEnabled] call CBA_fnc_addPerFrameHandler;
 };

--- a/addons/acre2/XEH_postInit.sqf
+++ b/addons/acre2/XEH_postInit.sqf
@@ -20,8 +20,8 @@ if (getMissionConfigValue ['TMF_AcreBabelEnabled',false]) then {
 };
 
 /// Parse Radios
-
-if (getMissionConfigValue ['TMF_AcreNetworkEnabled',false]) then {
+private _tmfNetworkEnabled = (getMissionConfigValue ['TMF_AcreNetworkEnabled',false]);
+if (_tmfNetworkEnabled) then {
     if (isNil QGVAR(radioCoreSettings)) then {
         GVAR(radioCoreSettings) = [
             // Array of Radio names, min freq, max freq, freq step, freq spacing between channels (for channel alloication
@@ -88,10 +88,12 @@ if (getMissionConfigValue ['TMF_AcreNetworkEnabled',false]) then {
 if (hasInterface) then {
     [{
         if (isNull player) exitWith {};
-        if (isNil "tmf_acre2_networksCreated") exitWith {}; //Ensure presets are created
+        params ["_args"];
+        _args params ["_tmfNetworkEnabled"];
+        if (_tmfNetworkEnabled && isNil "tmf_acre2_networksCreated") exitWith {}; //Ensure presets are created
         if (isNil QEGVAR(common,VarSync)) exitWith {}; // Ensure vars are recieved.
         
         [] call FUNC(clientInit);
         [_this select 1] call CBA_fnc_removePerFrameHandler;
-    }, 1] call CBA_fnc_addPerFrameHandler;
+    }, 1,[_tmfNetworkEnabled]] call CBA_fnc_addPerFrameHandler;
 };


### PR DESCRIPTION
- Previously you would have to run custom Radio networks for the babel settings to be enforced.
- This allows Babel system to be used without custom radio networks