### PR TITLE
Fix some units not appearing in briefing menu in eden

### DIFF
--- a/addons/briefing/ui_scripts/BriefingSettings.sqf
+++ b/addons/briefing/ui_scripts/BriefingSettings.sqf
@@ -52,7 +52,7 @@ fn_removeGroupFromBrief = {
 
 switch _mode do {
     case "onLoad": {
-        private _playableUnits = ((AllMissionObjects "") select {
+        private _playableUnits = (((all3DENEntities select 0)+(all3DENEntities select 3)) select {
             (_x get3DENAttribute "ControlMP") IsEqualTo [true]
             ||
             (_x get3DENAttribute "ControlSP") IsEqualTo [true]


### PR DESCRIPTION
- Fix for units not always appearing in Briefing Screen #221