### PR TITLE
Add Facesets

### DIFF
--- a/addons/assigngear/CfgEventHandlers.hpp
+++ b/addons/assigngear/CfgEventHandlers.hpp
@@ -1,0 +1,5 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};

--- a/addons/assigngear/CfgFaceSets.hpp
+++ b/addons/assigngear/CfgFaceSets.hpp
@@ -1,0 +1,11 @@
+class GVAR(facesets) {
+    class african {
+        // Classname
+        class AfricanHead_01 {
+            probability = 0.1;
+        };
+        class AfricanHead_02 {
+            probability = 0.2;
+        };
+    };
+};

--- a/addons/assigngear/CfgFunctions.hpp
+++ b/addons/assigngear/CfgFunctions.hpp
@@ -15,6 +15,7 @@ class cfgFunctions {
             class replaceSidearmWeapon;
             class helper;
             class saveRole;
+            class setFace;
             class onEdenMessageRecieved;
             class onEdenMissionChange;
         };

--- a/addons/assigngear/XEH_preStart.sqf
+++ b/addons/assigngear/XEH_preStart.sqf
@@ -1,0 +1,33 @@
+#include "script_component.hpp"
+
+// Cache the facesets to uiNamespace.
+
+// Collect valid face classes.
+private _faceClasses = [];
+{
+    _faceClasses append (("true" configClasses _x) apply {toLower (configName _x)});
+} forEach ("true" configClasses(configfile >> "CfgFaces"));
+
+uiNamespace setVariable ["tmf_assignGear_validFaces",_faceClasses];
+
+{
+	private _class = _x;
+	private _name = configName _x;
+
+	private _weightedArray = [];
+	{
+		private _faceClass = _x;
+		private _faceName = toLower (configName _faceClass);
+
+		private _probability = getNumber (_x >> "probability");
+		if (_probability isEqualTo 0) then {_probability = 1;};
+		// Validate it's a valid face.
+		if (_faceName in _faceClasses) then {
+			_weightedArray append [_faceName,_probability];
+		};
+	} forEach ("true" configClasses _class);
+	if (count _weightedArray > 0) then {
+		uiNamespace setVariable ["tmf_assignGear_faceset_"+_name,_weightedArray];
+	};
+} forEach ("true" configClasses (configFile >> "tmf_assignGear_facesets"));
+

--- a/addons/assigngear/config.cpp
+++ b/addons/assigngear/config.cpp
@@ -33,4 +33,6 @@ class RscDisplayArsenal
 #include "CfgFunctions.hpp"
 #include "CfgLoadouts.hpp"
 #include "Cfg3DEN.hpp"
+#include "CfgFaceSets.hpp"
 #include "display3DEN.hpp"
+

--- a/addons/assigngear/functions/fn_assignGear.sqf
+++ b/addons/assigngear/functions/fn_assignGear.sqf
@@ -132,8 +132,9 @@ private _items = GETGEAR("items");
 private _linkedItems = GETGEAR("linkedItems");
 private _backpackItems = GETGEAR("backpackItems");
 
-// Get code line
+// Other
 private _code = GETGEAR("code");
+private _faces = GETGEAR("faces");
 
 // Strip unit
 removeAllWeapons _unit;
@@ -165,6 +166,9 @@ else {
 // Replace secondary weapon and sidearm
 [_unit,_secondaryWeapon,_secondaryAttachments] call FUNC(replaceSecondaryWeapon);
 [_unit,_sidearmWeapon,_sidearmAttachments]     call FUNC(replaceSidearmWeapon);
+
+// Set Face
+[_unit,_faces] call FUNC(setFace);
 
 // Execute code statement
 if ((count _code) > 0) then {_unit call compile _code};

--- a/addons/assigngear/functions/fn_setFace.sqf
+++ b/addons/assigngear/functions/fn_setFace.sqf
@@ -1,0 +1,32 @@
+/*
+ * Name = TMF_assignGear_fnc_setFace
+ * Author = Nick
+ *
+ * Arguments:
+ * 0: Object. Unit
+ * 1: ARRAY. Array of faces to choose from
+ *
+ * Return:
+ * 0: String. Selected face
+ *
+ * Description:
+ * Will set a units face to a randomly chosen one from the supplied list.
+ */
+ #include "\x\tmf\addons\assignGear\script_component.hpp"
+params ["_unit","_faces"];
+private _face = "";
+
+if (isNil "_unit" || isNil "_faces") exitWith {};
+
+private _faceClasses = [];
+{
+    _faceClasses append (("true" configClasses _x) apply {configName _x});
+} forEach ("true" configClasses(configfile >> "CfgFaces"));
+_faces = _faces select {_x in _faceClasses}; // Need to maintain multiply identical entries to weigh chances
+
+if (count _faces > 0) then {
+    private _face = selectRandom _faces;
+    [_unit,_face] remoteExec ["setFace",0,_unit];
+    _unit setFace _face;
+};
+_face

--- a/addons/assigngear/functions/fn_setFace.sqf
+++ b/addons/assigngear/functions/fn_setFace.sqf
@@ -18,14 +18,15 @@ private _face = "";
 
 if (isNil "_unit" || isNil "_faces") exitWith {};
 
-private _faceClasses = [];
-{
-    _faceClasses append (("true" configClasses _x) apply {configName _x});
-} forEach ("true" configClasses(configfile >> "CfgFaces"));
-_faces = _faces select {_x in _faceClasses}; // Need to maintain multiply identical entries to weigh chances
-
 if (count _faces > 0) then {
     private _face = selectRandom _faces;
+    if ((_face find "faceset:") isEqualTo 0) then {
+        private _facesetName = _face select [8];
+        private _array = uiNamespace getVariable ["tmf_assignGear_faceset_" + _facesetName,[]];
+        if (count _array > 0) then {
+            _face = selectRandomWeighted _array;
+        };
+    };
     [_unit,_face] remoteExec ["setFace",0,_unit];
     _unit setFace _face;
 };

--- a/addons/assigngear/loadouts/blu_f.hpp
+++ b/addons/assigngear/loadouts/blu_f.hpp
@@ -1,13 +1,15 @@
 class baseMan {// Weaponless baseclass
     displayName = "Unarmed";
     // All randomized.
-     uniform[] = {"U_B_CombatUniform_mcam","U_B_CombatUniform_mcam_vest"};
-       vest[] = {"V_PlateCarrier1_rgr","V_PlateCarrier2_rgr"};
-       backpack[] = {"B_AssaultPack_mcamo"};
-       headgear[] = {};
-       goggles[] = {"default"};
-       hmd[] = {};
+    uniform[] = {"U_B_CombatUniform_mcam","U_B_CombatUniform_mcam_vest"};
+    vest[] = {"V_PlateCarrier1_rgr","V_PlateCarrier2_rgr"};
+    backpack[] = {"B_AssaultPack_mcamo"};
+    headgear[] = {};
+    goggles[] = {"default"};
+    hmd[] = {};
     // Leave empty to remove all. "Default" > leave original item.
+    faces[] = {};
+    // Leave empty to not change faces.
 
     // All randomized
     primaryWeapon[] = {};
@@ -72,7 +74,7 @@ class car : r
     displayName = "Carabinier";
     primaryWeapon[] = {"arifle_MXC_F"};
 };
-class m : car 
+class m : car
 {
     displayName = "Medic";
 };

--- a/addons/assigngear/loadouts/civ_f.hpp
+++ b/addons/assigngear/loadouts/civ_f.hpp
@@ -8,6 +8,8 @@ class baseMan {// Weaponless baseclass
     goggles[] = {"default"};
     hmd[] = {};
     // Leave empty to remove all. "Default" > leave original item.
+    faces[] = {};
+    // Leave empty to not change faces.
 
     // All randomized
     primaryWeapon[] = {};

--- a/addons/assigngear/loadouts/fia_f.hpp
+++ b/addons/assigngear/loadouts/fia_f.hpp
@@ -18,6 +18,8 @@ class baseMan {// Weaponless baseclass
     goggles[] = {"default"};
     hmd[] = {};
     // Leave empty to remove all. "Default" > leave original item.
+    faces[] = {};
+    // Leave empty to not change faces.
 
     // All randomized
     primaryWeapon[] = {};
@@ -89,7 +91,7 @@ class car : r
     displayName = "Carabinier";
     primaryWeapon[] = {"arifle_TRG20_F"};
 };
-class m : car 
+class m : car
 {
     displayName = "Medic";
 };

--- a/addons/assigngear/loadouts/ind_f.hpp
+++ b/addons/assigngear/loadouts/ind_f.hpp
@@ -8,6 +8,8 @@ class baseMan {// Weaponless baseclass
     goggles[] = {"default"};
     hmd[] = {};
     // Leave empty to remove all. "Default" > leave original item.
+    faces[] = {};
+    // Leave empty to not change faces.
 
     // All randomized
     primaryWeapon[] = {};
@@ -72,7 +74,7 @@ class car : r
     displayName = "Carabinier";
     primaryWeapon[] = {"arifle_Mk20C_F"};
 };
-class m : car 
+class m : car
 {
     displayName = "Medic";
 };

--- a/addons/assigngear/loadouts/opf_f.hpp
+++ b/addons/assigngear/loadouts/opf_f.hpp
@@ -8,6 +8,8 @@ class baseMan {// Weaponless baseclass
     goggles[] = {"default"};
     hmd[] = {};
     // Leave empty to remove all. "Default" > leave original item.
+    faces[] = {};
+    // Leave empty to not change faces.
 
     // All randomized
     primaryWeapon[] = {};
@@ -72,7 +74,7 @@ class car : r
     displayName = "Carabinier";
     primaryWeapon[] = {"arifle_Katiba_C_F"};
 };
-class m : car 
+class m : car
 {
     displayName = "Medic";
 };

--- a/addons/autotest/functions/fn_testGear.sqf
+++ b/addons/autotest/functions/fn_testGear.sqf
@@ -46,6 +46,26 @@ private _fncTestUnit = {
         [_goggles, _cfgGlasses] call _fnc_checkExists;
         private _hmd = GETGEAR("hmd"); // "CfgGlasses"
         [_hmd, _cfgWeapons] call _fnc_checkExists;
+
+        // Test faces;
+        private _faces = GETGEAR("faces");
+        private _validFaces = uiNamespace getVariable ["tmf_assignGear_validFaces",[]];
+
+        {
+            private _face = toLower _x;
+             if ((_face find "faceset:") isEqualTo 0) then {
+                private _facesetName = _face select [8];
+                private _array = uiNamespace getVariable ["tmf_assignGear_faceset_" + _facesetName,0];
+                if (_array isEqualTo 0) then {
+                     _output pushBack [0,format["Invalid faceset: %1 (for: %2 - %3)", _face,_faction,_role]];  
+                };
+            } else {
+                if (!(_face in _validFaces)) then {
+                    _output pushBack [0,format["Invalid face classname: %1 (for: %2 - %3)", _face,_faction,_role]];  
+                };
+            };
+        } forEach _faces;
+
         // Get primary weapon and items
         private _primaryWeapon = GETGEAR("primaryWeapon"); //CfgWeapons"
         [_primaryWeapon, _cfgWeapons] call _fnc_checkExists;


### PR DESCRIPTION
- Building on #197 with Bear's suggestions in #156
- **Adds facesets**
Facesets must be defined in mod adding entries to the class `tmf_assignGear_facesets`
Example from assigngear:
`faces[] = {"faceset:african","AfricanHead_01","notexist","faceset:nn"};`
- Adds autotest capability:
![image](https://user-images.githubusercontent.com/7645788/46636478-0e261880-cb50-11e8-9f3e-587361220c5b.png)
- TODO: Expand base included facesets.
