### PR TITLE
Enhance equipment briefing page

### DIFF
--- a/addons/briefing/functions/fn_unitPage.sqf
+++ b/addons/briefing/functions/fn_unitPage.sqf
@@ -15,39 +15,21 @@
 #include "\x\tmf\addons\briefing\script_component.hpp"
 params ["_target","_units"];
 
-// ==========================
-
-// Local function to set the proper magazine count.
-private _fnc_wepMags = {
-    params["_weapon"];
-    private _ret = "";
-
-    //Get possible magazines for weapon
-    private _wepMags = getArray(configFile >> "CfgWeapons" >> _weapon >> "magazines");
-
-    // Compare weapon magazines with unit magazines
-    private _magArray = [];
+private _fnc_weaponMags = {
+    params ["_weapon"];
+    
+    private _compatibleMags = [_weapon] call CBA_fnc_compatibleMagazines;
+    private _carriedMags = [];
+    
     {
-        // findInPairs returns the first index that matches the checked for magazine
-        private _idx = [_mags,_x] call BIS_fnc_findInPairs;
-        // If we have a match
+        private _idx = [_mags, _x] call BIS_fnc_findInPairs;
         if (_idx != -1) then {
-            // Add the number of magazines to the list
-            _magArray pushBack ([_mags,[_idx, 1]] call BIS_fnc_returnNestedElement);;
-            // Remove the entry
-            _mags = [_mags, _idx] call BIS_fnc_removeIndex;
+            _carriedMags pushBack +(_mags select _idx);
+            _mags deleteAt _idx;
         };
-    } forEach _wepMags;
-
-    if (count _magArray > 0) then {
-        _ret = " [";
-        {
-            _ret = _ret + format ["%1",_x];
-            if (count _magArray > (_forEachIndex + 1)) then {_ret = _ret + "+";}
-        } forEach _magArray;
-        _ret = _ret + "]";
-    };
-    _ret
+    } forEach _compatibleMags;
+    
+    _carriedMags
 };
 
 // ==========================
@@ -74,7 +56,7 @@ private _cfgWeapons = configFile >> "CfgWeapons";
 
     private _weaponText = "";
     private _otherText = "";
-    private _backPackText = "";
+    private _gearText = "";
     private _itemText = "";
     // Do this before _mags is deleted from
 
@@ -93,13 +75,14 @@ private _cfgWeapons = configFile >> "CfgWeapons";
 
     // Weapons
     if (count _weapons > 0) then {
-        _weaponText = _weaponText + "<font size='18'>WEAPONS:</font>";
+        _weaponText = _weaponText + "<font size='18'>WEAPONS</font>";
         {
             private _weapon = _x;
             private _cfg = _cfgWeapons >> _weapon;
+            if (_forEachIndex > 0) then {
+                _weaponText = _weaponText + "<br/>";
+            };
             _weaponText = _weaponText + format["<br/>%1",getText( _cfg >> "displayname")];
-            // Add magazines for the weapon
-            _weaponText = _weaponText + ([_weapon] call _fnc_wepMags);
 
             // Check for grenadier rifles
             private _muzzles = getArray(_cfg >> "muzzles");
@@ -110,7 +93,6 @@ private _cfgWeapons = configFile >> "CfgWeapons";
             _subClasses = _subClasses select {(toLower _x) in _muzzles};
             {
                 _weaponText = _weaponText + "<br/> <img image='\A3\ui_f\data\igui\cfg\weaponicons\GL_ca.paa' height='16'/> UGL";
-                _weaponText = _weaponText + ([_x] call _fnc_wepMags);
             } forEach _subClasses;
 
             // Get weapon icon
@@ -129,6 +111,11 @@ private _cfgWeapons = configFile >> "CfgWeapons";
                     _visText = _visText + format["<img image='%1' height=48 />",_icon];
                 };
             } forEach _attachments;
+            
+            private _weaponMags = _weapon call _fnc_weaponMags;
+            {
+                _weaponText = _weaponText + format ["<br/>          %1 [%2]", getText (configFile >> "CfgMagazines" >> (_x select 0) >> "displayName"), _x select 1];
+            } forEach _weaponMags;
         } forEach _weapons;
         _weaponText = _weaponText + "<br/>";
         _visText = _visText + "<br/>";
@@ -136,17 +123,23 @@ private _cfgWeapons = configFile >> "CfgWeapons";
 
     // All magazines not tied to weapons (grenades etc.)
     if (count _mags > 0) then {
-        _otherText = _otherText + "<br/><font size='18'>OTHER:</font><br/>";
+        _otherText = _otherText + "<br/><font size='18'>OTHER</font><br/>";
         {
             _otherText = _otherText + format["%1 [%2]<br/>",getText(_cfgMagazines >> (_x select 0) >> "displayName"),_x select 1];
         } forEach _mags;
     };
     _visText = _visText + "<br/>" + _magVisText + "<br/>";
 
-    // Backpacks
-    if !(backpack _unit == "") then {
-        _backPackText = _backPackText + "<br/><font size='18'>BACKPACK:</font><br/>";
-        _backPackText = _backPackText + format["%1 [%2",getText (configFile >> "CfgVehicles" >> (backpack _unit) >> "displayName"), round(100*loadBackpack _unit)]+"% Full]<br/>";
+    // Gear
+    _gearText = _gearText + "<br/><font size='18'>GEAR</font><br/>";
+    if !((uniform _unit) isEqualTo "") then {
+        _gearText = _gearText + format ["Uniform: %1 [%2", getText (configFile >> "CfgWeapons" >> (uniform _unit) >> "displayName"), round (100 * loadUniform _unit)] + "% full]<br/>";
+    };
+    if !((vest _unit) isEqualTo "") then {
+        _gearText = _gearText + format ["Gear: %1 [%2", getText (configFile >> "CfgWeapons" >> (vest _unit) >> "displayName"), round (100 * loadVest _unit)] + "% full]<br/>";
+    };
+    if !((backpack _unit) isEqualTo "") then {
+        _gearText = _gearText + format ["Backpack: %1 [%2", getText (configFile >> "CfgVehicles" >> (backpack _unit) >> "displayName"), round (100 * loadBackpack _unit)] + "% full]<br/>";
     };
 
     // Misc. Items
@@ -167,33 +160,32 @@ private _cfgWeapons = configFile >> "CfgWeapons";
 
         _itemText = _itemText + "<br/><img image='\A3\ui_f\data\gui\rscCommon\rscCheckBox\checkBox_checked_ca.paa' height='16'/>Indicates an equipped item.";
     };
+    
+    _text = _text + _weaponText + _otherText + _gearText + _itemText;
+
+    private _roleName = "";
+    private _faction = _unit getVariable [QEGVAR(assigngear,faction), ""];
+    private _role = _unit getVariable [QEGVAR(assigngear,role), ""];
+    
+    if !(_faction isEqualTo "") then {
+        private _classFaction = (missionConfigFile >> "CfgLoadouts" >> _faction);
+        if (isNull _classFaction) then {
+            _classFaction = (configFile >> "CfgLoadouts" >> _faction);
+        };
+        
+        if (!isNull _classFaction) then {
+            _roleName = getText (_classFaction >> _role >> "displayName");
+        };
+    };
+    
+    if (!isNil "ace_common_fnc_getWeight") then {
+        _text = _text + format ["<br/><br/>Total Weight: %1 (%2)", [_unit] call ace_common_fnc_getWeight, [_unit, true] call ace_common_fnc_getWeight];
+    };
 
     // Add the created text
-    private _roleName = "";
-    if (_unit getVariable ['TMF_assignGear_enabled',false]) then {
-        private _classes = [];
-        private _side = _unit getVariable [QEGVAR(assignGear,side),((side _unit) call EFUNC(common,sideToNum))];
-        _side = toLower([_side] call CFUNC(sideType));
-
-        private _faction = _unit getVariable [QEGVAR(assignGear,faction), toLower(faction _unit)];
-        private _role = _unit getVariable [QEGVAR(assignGear,role), "r"];
-
-        if(isClass (configFile >> "CfgLoadouts" >> _side >> _faction) && count _classes <= 0) then {_classes = configProperties [configFile >> "CfgLoadouts" >> _side >> _faction,"isClass _x"];};
-        if(isClass (missionConfigFile >> "CfgLoadouts" >> _side >> _faction)) then {_classes = configProperties [missionConfigFile >> "CfgLoadouts" >> _side >> _faction,"isClass _x"];};
-        {
-            if(configName _x == _role) exitWith {_roleName = getText(_x >> "displayName");};
-        } forEach _classes;
-    };
-
     private _entryString = (name _unit);
-    if (_roleName != "") then {
-        _entryString = _entryString + format[" [Kit: %1]",_roleName];
+    if !(_roleName isEqualTo "") then {
+        _entryString = _entryString + format [" [%1]", _roleName];
     };
-
-    if (!isNil "ace_movement_fnc_getWeight") then {
-        _visText = format["Total Weight: %1 <br/>",([_unit] call ace_movement_fnc_getWeight)] + _visText;
-    };
-
-    _text = _text + _weaponText + _otherText + _backPackText + _itemText;
     _target createDiaryRecord ["loadout", [_entryString, "<font size='12'>NOTE: The loadout shown below is only accurate at mission start.</font><br/>" + _visText + _text]];
 } forEach _units;


### PR DESCRIPTION
Now displays
- Role from assigngear component
- Types of magazines given, instead of just e.g. [6+1] count after weapon name
- Uniform and vest (previously only backpack)
- Total weight (if ACE3 is loaded)

![20181121122035_1](https://user-images.githubusercontent.com/9511798/48838796-bc48f300-ed89-11e8-8c83-4c5e55a737d7.jpg)