### PR TITLE
AI Loadout Macro system

### DIFF
--- a/addons/ai/functions/fn_spawnWave.sqf
+++ b/addons/ai/functions/fn_spawnWave.sqf
@@ -11,7 +11,16 @@ _data = _logic getVariable [QGVAR(waveData), []];
         _x params ["_type","_pos","_dir","_gear"];
         _unit = _grp createUnit [_type, _pos,[] , 0, "NONE"];
         _unit setPosATL _pos;
-        _unit setUnitLoadout [_gear, false];
+
+        if (_gear isEqualTypeArray ["",""]) then
+        {
+            ([_unit] + _gear) call EFUNC(assigngear,assignGear);
+        }
+        else
+        {
+            _unit setUnitLoadout _gear;
+        };
+
         _unit setDir _dir;
     } forEach _units;
 
@@ -28,7 +37,16 @@ _data = _logic getVariable [QGVAR(waveData), []];
             _x params ["_type","_pos","_gear"];
             _unit = _grp createUnit [_type, _pos,[] , 0, "NONE"];
             _unit moveInAny _vehicle;
-            _unit setUnitLoadout [_gear, false];
+
+            if (_gear isEqualTypeArray ["",""]) then
+            {
+                ([_unit] + _gear) call EFUNC(assigngear,assignGear);
+            }
+            else
+            {
+                _unit setUnitLoadout _gear;
+            };
+
         } forEach _units;
     } forEach _vehicles;
 

--- a/addons/assigngear/Cfg3DEN.hpp
+++ b/addons/assigngear/Cfg3DEN.hpp
@@ -66,6 +66,17 @@ class Cfg3DEN
                         value = "''";
                         wikiType = "[[String]]";
                     };
+                    class TMF_aiGear_disabled
+                    {
+                        property = "TMF_aiGear_disabled";
+                        displayName = "Disable AI Macro for unit";
+                        tooltip = "Allows for arsenal loadouts to be used. Players/units with TMF loadouts are skipped. Requires module 'AI Loadout Macro'";
+                        condition = "objectBrain";
+                        control = "Checkbox";
+                        expression = "_this setVariable ['TMF_aiGear_disabled',_value,true];";
+                        defaultValue = "false";
+                        wikiType = "[[Bool]]";
+                    };
                     class TMF_assignGear_full
                     {
                         property = "TMF_assignGear_full";

--- a/addons/assigngear/Cfg3DEN.hpp
+++ b/addons/assigngear/Cfg3DEN.hpp
@@ -128,7 +128,7 @@ class Cfg3DEN
             attributeSave = "\
                 _ctrlFaction = _this controlsGroupCtrl 100;\
                 private _output = _ctrlFaction lbData lbCurSel _ctrlFaction;\
-                private _objects = get3DENSelected 'object'; \
+                private _objects = (get3DENSelected 'object' + get3DENSelected 'logic'); \
                 { \
                     private _array = [(_x get3DENAttribute 'TMF_assignGear_role') select 0, \
                     _output, \
@@ -168,7 +168,7 @@ class Cfg3DEN
             attributeSave = "\
                 _ctrlRole = _this controlsGroupCtrl 100;\
                 private _output = _ctrlRole lbData lbCurSel _ctrlRole;\
-                private _objects = get3DENSelected 'object'; \
+                private _objects = (get3DENSelected 'object' + get3DENSelected 'logic'); \
                 { \
                     _array = [_output, \
                     (_x get3DENAttribute 'TMF_assignGear_faction') select 0, \

--- a/addons/assigngear/CfgEventHandlers.hpp
+++ b/addons/assigngear/CfgEventHandlers.hpp
@@ -3,3 +3,11 @@ class Extended_PreStart_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_preStart));
     };
 };
+
+class Extended_InitPost_EventHandlers {
+    class CAManBase {
+        class ADDON {
+            init = QUOTE(_this call COMPILE_FILE(XEH_unitInit));
+        };
+    };
+};

--- a/addons/assigngear/CfgFunctions.hpp
+++ b/addons/assigngear/CfgFunctions.hpp
@@ -20,6 +20,7 @@ class cfgFunctions {
             class saveRole;
             class setFace;
             class setInsignia;
+            class setVoice;
             class onEdenMessageRecieved;
             class onEdenMissionChange;
         };

--- a/addons/assigngear/CfgFunctions.hpp
+++ b/addons/assigngear/CfgFunctions.hpp
@@ -23,6 +23,7 @@ class cfgFunctions {
             class setVoice;
             class onEdenMessageRecieved;
             class onEdenMissionChange;
+            class unitInit;
         };
     };
 };

--- a/addons/assigngear/CfgFunctions.hpp
+++ b/addons/assigngear/CfgFunctions.hpp
@@ -5,10 +5,12 @@ class cfgFunctions {
             class addBackpackItems;
             class addItems;
             class assignGear;
+            class assignAIGear;
             class linkItems;
             class loadFactions;
             class loadFactionCategories;
             class loadRoles;
+            class replaceAIWeapon;
             class replaceEquipment;
             class replacePrimaryWeapon;
             class replaceSecondaryWeapon;

--- a/addons/assigngear/CfgFunctions.hpp
+++ b/addons/assigngear/CfgFunctions.hpp
@@ -14,6 +14,7 @@ class cfgFunctions {
             class replaceSecondaryWeapon;
             class replaceSidearmWeapon;
             class helper;
+            class moduleAIMacro;
             class saveRole;
             class setFace;
             class setInsignia;

--- a/addons/assigngear/CfgModules.hpp
+++ b/addons/assigngear/CfgModules.hpp
@@ -1,0 +1,22 @@
+class CfgVehicles
+{
+    class Logic;
+    class Module_F: Logic
+    {
+        class AttributesBase
+        {
+            class Default;
+            class Edit; // Default edit box (i.e., text input field)
+            class Combo; // Default combo box (i.e., drop-down menu)
+            class Checkbox; // Default checkbox (returned value is Bool)
+            class CheckboxNumber; // Default checkbox (returned value is Number)
+            class ModuleDescription; // Module description
+            class Units; // Selection of units on which the module is applied
+        };
+        class ModuleDescription
+        {
+            class logicModule;
+        };
+    };
+    #include "modules\loadoutMacro.hpp"
+};

--- a/addons/assigngear/CfgVoiceSets.hpp
+++ b/addons/assigngear/CfgVoiceSets.hpp
@@ -1,0 +1,60 @@
+class GVAR(voiceSets) {
+    americanEnglish[] = {
+        "Male01ENG",
+        "Male02ENG",
+        "Male03ENG",
+        "Male04ENG",
+        "Male05ENG",
+        "Male06ENG",
+        "Male07ENG",
+        "Male08ENG",
+        "Male09ENG",
+        "Male10ENG",
+        "Male11ENG",
+        "Male12ENG"
+    };
+    britishEnglish[] = {
+        "Male01ENGB",
+        "Male02ENGB",
+        "Male03ENGB",
+        "Male04ENGB",
+        "Male05ENGB"
+    };
+    frenchEnglish[] = {
+        "Male01ENGFRE",
+        "Male02ENGFRE"
+    };
+    altianEnglish[] = {
+        "Male01GRE",
+        "Male02GRE",
+        "Male03GRE",
+        "Male04GRE",
+        "Male05GRE",
+        "Male06GRE"
+    };
+    asianFrench[] = {
+        "Male01FRE",
+        "Male02FRE",
+        "Male03FRE"
+    };
+    russian[] = {
+        "Male01RUS",
+        "Male02RUS",
+        "Male03RUS"
+    };
+    chinese[] = {
+        "Male01CHI",
+        "Male02CHI",
+        "Male03CHI"
+    };
+    polish[] = {
+        "Male01POL",
+        "Male02POL",
+        "Male03POL"
+    };
+    farsi[] = {
+        "Male01PER",
+        "Male02PER",
+        "Male03PER"
+    };
+};

--- a/addons/assigngear/XEH_preStart.sqf
+++ b/addons/assigngear/XEH_preStart.sqf
@@ -31,8 +31,6 @@ uiNamespace setVariable [QGVAR(validFaces),_faceClasses];
     };
 } forEach ("true" configClasses (configFile >> QGVAR(facesets)));
 
-// Cache the voicesets to uiNamespace.
-
 // Collect valid voice classes.
 
 private _voiceClasses = "true" configClasses (configfile >> "CfgVoice");
@@ -40,6 +38,7 @@ MAP(_voiceClasses, toLower configName _x);
 
 uiNamespace setVariable [QGVAR(validVoices),_voiceClasses];
 
+// Cache the voicesets to uiNamespace.
 {
     private _name = configName _x;
 

--- a/addons/assigngear/XEH_preStart.sqf
+++ b/addons/assigngear/XEH_preStart.sqf
@@ -8,7 +8,7 @@ private _faceClasses = [];
     _faceClasses append (("true" configClasses _x) apply {toLower (configName _x)});
 } forEach ("true" configClasses(configfile >> "CfgFaces"));
 
-uiNamespace setVariable ["tmf_assignGear_validFaces",_faceClasses];
+uiNamespace setVariable [QGVAR(validFaces),_faceClasses];
 
 {
     private _class = _x;
@@ -27,7 +27,30 @@ uiNamespace setVariable ["tmf_assignGear_validFaces",_faceClasses];
         };
     } forEach ("true" configClasses _class);
     if (count _weightedArray > 0) then {
-        uiNamespace setVariable ["tmf_assignGear_faceset_"+_name,_weightedArray];
+        uiNamespace setVariable [QGVAR(faceset_)+_name,_weightedArray];
     };
-} forEach ("true" configClasses (configFile >> "tmf_assignGear_facesets"));
+} forEach ("true" configClasses (configFile >> QGVAR(facesets)));
 
+// Cache the voicesets to uiNamespace.
+
+// Collect valid voice classes.
+
+private _voiceClasses = "true" configClasses (configfile >> "CfgVoice");
+MAP(_voiceClasses, {toLower _x});
+
+uiNamespace setVariable [QGVAR(validVoices),_voiceClasses];
+
+{
+    private _name = configName _x;
+
+    private _voiceSet = getArray _x;
+
+    MAP(_voiceSet, {toLower _x});
+    INTERSECTION(_voiceSet, _voiceClasses);
+
+    if (count _voiceSet > 0) then
+    {
+        uiNamespace setVariable [QGVAR(voiceset_)+_name,_arr]
+    };
+
+} forEach configProperties [configFile >> QGVAR(voicesets)];

--- a/addons/assigngear/XEH_preStart.sqf
+++ b/addons/assigngear/XEH_preStart.sqf
@@ -36,7 +36,7 @@ uiNamespace setVariable [QGVAR(validFaces),_faceClasses];
 // Collect valid voice classes.
 
 private _voiceClasses = "true" configClasses (configfile >> "CfgVoice");
-MAP(_voiceClasses, {toLower _x});
+MAP(_voiceClasses, toLower configName _x);
 
 uiNamespace setVariable [QGVAR(validVoices),_voiceClasses];
 
@@ -45,12 +45,12 @@ uiNamespace setVariable [QGVAR(validVoices),_voiceClasses];
 
     private _voiceSet = getArray _x;
 
-    MAP(_voiceSet, {toLower _x});
+    MAP(_voiceSet, toLower _x);
     INTERSECTION(_voiceSet, _voiceClasses);
 
     if (count _voiceSet > 0) then
     {
-        uiNamespace setVariable [QGVAR(voiceset_)+_name,_arr]
+        uiNamespace setVariable [QGVAR(voiceset_)+_name,_voiceSet]
     };
 
 } forEach configProperties [configFile >> QGVAR(voicesets)];

--- a/addons/assigngear/XEH_unitInit.sqf
+++ b/addons/assigngear/XEH_unitInit.sqf
@@ -4,17 +4,5 @@
 
 params [["_unit", objNull]];
 
-if
-(
-    isNull _unit ||
-    {isNil (QGVAR(aiGear_) + str side _unit)} ||
-    {!local _unit} ||
-    {isPlayer _unit} ||
-    {_unit in (playableUnits + [player])} ||
-    {_unit getVariable [QGVAR(done), false]} ||
-    {_unit getVariable ["TMF_aiGear_disabled", false]}
-) exitWith {};
-
-private _config = missionNamespace getVariable (QGVAR(aiGear_) + str side _unit);
-
-[_unit, _config] call FUNC(assignAIGear);
+// Assign AI gear
+[_unit] call FUNC(unitInit);

--- a/addons/assigngear/XEH_unitInit.sqf
+++ b/addons/assigngear/XEH_unitInit.sqf
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+params [["_unit", objNull]];
+
+if
+(
+    isNull _unit ||
+    {!local _unit} ||
+    {isPlayer _unit} ||
+    {_unit in playableUnits} ||
+    {isNil (QGVAR(aiGear_) + str side _unit)} ||
+    {_unit getVariable [QGVAR(done), false]}
+) exitWith {};
+
+private _config = missionNamespace getVariable (QGVAR(aiGear_) + str side _unit);
+
+[_unit, _config] call FUNC(assignAIGear);

--- a/addons/assigngear/XEH_unitInit.sqf
+++ b/addons/assigngear/XEH_unitInit.sqf
@@ -12,6 +12,7 @@ if
     {isPlayer _unit} ||
     {_unit in playableUnits} ||
     {_unit getVariable [QGVAR(done), false]} ||
+    {_unit getVariable ["TMF_aiGear_disabled", false]} ||
     {!is3den || {(_unit get3DENAttribute 'ControlSP') # 0 || (_unit get3DENAttribute 'ControlMP') # 0}}
 ) exitWith {};
 

--- a/addons/assigngear/XEH_unitInit.sqf
+++ b/addons/assigngear/XEH_unitInit.sqf
@@ -1,15 +1,18 @@
 #include "script_component.hpp"
 
+// This file is called from fn_moduleAIMacro, may need changes if edited
+
 params [["_unit", objNull]];
 
 if
 (
     isNull _unit ||
+    {isNil (QGVAR(aiGear_) + str side _unit)} ||
     {!local _unit} ||
     {isPlayer _unit} ||
     {_unit in playableUnits} ||
-    {isNil (QGVAR(aiGear_) + str side _unit)} ||
-    {_unit getVariable [QGVAR(done), false]}
+    {_unit getVariable [QGVAR(done), false]} ||
+    {!is3den || {(_unit get3DENAttribute 'ControlSP') # 0 || (_unit get3DENAttribute 'ControlMP') # 0}}
 ) exitWith {};
 
 private _config = missionNamespace getVariable (QGVAR(aiGear_) + str side _unit);

--- a/addons/assigngear/XEH_unitInit.sqf
+++ b/addons/assigngear/XEH_unitInit.sqf
@@ -10,10 +10,9 @@ if
     {isNil (QGVAR(aiGear_) + str side _unit)} ||
     {!local _unit} ||
     {isPlayer _unit} ||
-    {_unit in playableUnits} ||
+    {_unit in (playableUnits + [player])} ||
     {_unit getVariable [QGVAR(done), false]} ||
-    {_unit getVariable ["TMF_aiGear_disabled", false]} ||
-    {!is3den || {(_unit get3DENAttribute 'ControlSP') # 0 || (_unit get3DENAttribute 'ControlMP') # 0}}
+    {_unit getVariable ["TMF_aiGear_disabled", false]}
 ) exitWith {};
 
 private _config = missionNamespace getVariable (QGVAR(aiGear_) + str side _unit);

--- a/addons/assigngear/config.cpp
+++ b/addons/assigngear/config.cpp
@@ -34,5 +34,6 @@ class RscDisplayArsenal
 #include "CfgLoadouts.hpp"
 #include "Cfg3DEN.hpp"
 #include "CfgFaceSets.hpp"
+#include "CfgVoiceSets.hpp"
 #include "display3DEN.hpp"
 #include "CfgModules.hpp"

--- a/addons/assigngear/config.cpp
+++ b/addons/assigngear/config.cpp
@@ -35,4 +35,4 @@ class RscDisplayArsenal
 #include "Cfg3DEN.hpp"
 #include "CfgFaceSets.hpp"
 #include "display3DEN.hpp"
-
+#include "CfgModules.hpp"

--- a/addons/assigngear/functions/fn_assignAIGear.sqf
+++ b/addons/assigngear/functions/fn_assignAIGear.sqf
@@ -1,0 +1,67 @@
+/*
+ * Name = TMF_assignGear_fnc_assignGear
+ * Author = Nick
+ *
+ * Arguments:
+ * 0: Object. Unit to assign gear to
+ * 1: Number (optional). Numeric value of side of unit. Defaults to 3DEN attributes
+ * 2: String (optional). Which faction to use. Defaults to 3DEN attributes
+ * 3: String (optional). Which role to use. Defaults to 3DEN attributes
+ *
+ * Return:
+ * None
+ *
+ * Description:
+ * Dresses up a unit with the assignGear system
+ */
+#include "\x\tmf\addons\assignGear\script_component.hpp"
+
+params ["_unit", "_params"];
+_params params ["_cfg", "_useTracer", "_addMedical", "_addHMD", "_addFlashlight", "_forceFlashlight", "_code"];
+
+removeAllWeapons _unit;
+removeAllAssignedItems _unit;
+removeAllItemsWithMagazines _unit;
+_unit assignItem "itemRadio";
+_unit setVariable ["BIS_enableRandomization", false];
+
+[_unit, "uniform",  GETGEAR("uniform")] call FUNC(replaceEquipment);
+[_unit, "vest",     GETGEAR("vest")] call FUNC(replaceEquipment);
+[_unit, "backpack", GETGEAR("backpack")] call FUNC(replaceEquipment);
+[_unit, "headgear", GETGEAR("headgear")] call FUNC(replaceEquipment);
+[_unit, "goggles",  GETGEAR("goggles")] call FUNC(replaceEquipment);
+[_unit, "hmd",      GETGEAR("hmd")] call FUNC(replaceEquipment);
+
+if (_addMedical) then
+{
+    if (_unit getUnitTrait "Medic") then
+    {
+        for "_i" from 1 to 3 do {_unit addItem "FirstAidKit";};
+        _unit addItem "Medikit";
+    }
+    else
+    {
+        _unit addItem "FirstAidKit";
+    };
+};
+
+[_unit, GETGEAR("primaryWeapon"), GETGEAR("scope"), _useTracer] call FUNC(replaceAIWeapon);
+[_unit, GETGEAR("secondaryWeapon")] call FUNC(replaceAIWeapon);
+[_unit, GETGEAR("sidearmWeapon")] call FUNC(replaceAIWeapon);
+
+// Add infinite magazines for unit, as the AI can't pick up magazines by themselves
+_unit addEventHandler ["Reloaded", {
+    params ["_unit", "_weapon", "_muzzle", "_newMagazine", "_oldMagazine"];
+
+    // Skip launchers
+    if (getNumber (configFile >> "CfgWeapons" >> _weapon >> "type") == 4) exitWith {};
+
+    _unit addMagazine (_oldMagazine # 0);
+}];
+
+{_unit addMagazine _x} forEach (GETGEAR("grenades"));
+
+if ((count GETGEAR("code")) > 0) then
+{
+    _unit call compile GETGEAR("code");
+};

--- a/addons/assigngear/functions/fn_assignAIGear.sqf
+++ b/addons/assigngear/functions/fn_assignAIGear.sqf
@@ -131,3 +131,5 @@ if (_code isEqualType {}) then
         _unit call compile _code;
     };
 };
+
+_unit setVariable [QGVAR(DOUBLES(aigear,done)), true, true];

--- a/addons/assigngear/functions/fn_assignAIGear.sqf
+++ b/addons/assigngear/functions/fn_assignAIGear.sqf
@@ -62,25 +62,37 @@ if (_addMedical) then
 [_unit, GETGEAR("secondaryWeapon"), [GETGEAR("backpack")]] call FUNC(replaceAIWeapon);
 [_unit, GETGEAR("sidearmWeapon")] call FUNC(replaceAIWeapon);
 
+
 if (_addFlashlight) then
 {
-    private _compatibleItems = (currentWeapon _unit) call BIS_fnc_compatibleItems;
+    private _weapon = currentWeapon _unit;
+    if (_weapon isEqualTo "") then
+    {
+        _weapon = primaryWeapon _unit;
 
-    // Check if vanilla flashlight is compatible, to avoid searching through configs
-    if ("acc_flashlight" in _compatibleItems) then
+    };
+    if !(_weapon isEqualTo "") then
     {
-        _unit addWeaponItem [currentWeapon _unit, "acc_flashlight"];
-    }
-    else
-    {
-        // Search through compatible items for flashlights
-        _unit addWeaponItem
-        [
-            currentWeapon _unit,
-            selectRandom (_compatibleItems select {1 <= getNumber (configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "FlashLight" >> "useFlare")})
-        ];
+        private _compatibleItems = _weapon call BIS_fnc_compatibleItems;
+
+        // Check if vanilla flashlight is compatible, to avoid searching through configs
+        // Known issue, won't display in 3DEN
+        if ("acc_flashlight" in _compatibleItems) then
+        {
+            _unit addWeaponItem [_weapon, "acc_flashlight"];
+        }
+        else
+        {
+            // Search through compatible items for flashlights
+            _unit addWeaponItem
+            [
+                _weapon,
+                selectRandom (_compatibleItems select {1 <= getNumber (configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "FlashLight" >> "useFlare")})
+            ];
+        };
     };
 };
+
 if (_forceFlashlight) then
 {
     _unit enableGunLights "ForceOn";

--- a/addons/assigngear/functions/fn_assignAIGear.sqf
+++ b/addons/assigngear/functions/fn_assignAIGear.sqf
@@ -40,6 +40,9 @@ if (_addMedical) then
         _unit addItem "Medikit";
     }
     else
+//Identity
+[_unit,GETGEAR("faces")] call FUNC(setFace);
+[_unit,GETGEAR("voices")] call FUNC(setVoice);
     {
         _unit addItem "FirstAidKit";
     };

--- a/addons/assigngear/functions/fn_assignAIGear.sqf
+++ b/addons/assigngear/functions/fn_assignAIGear.sqf
@@ -30,7 +30,7 @@ _unit setVariable ["BIS_enableRandomization", false];
 [_unit, "backpack", GETGEAR("backpack")] call FUNC(replaceEquipment);
 [_unit, "headgear", GETGEAR("headgear")] call FUNC(replaceEquipment);
 [_unit, "goggles",  GETGEAR("goggles")] call FUNC(replaceEquipment);
-[_unit, "hmd",      GETGEAR("hmd")] call FUNC(replaceEquipment);
+if (_addHMD) then {[_unit, "hmd", GETGEAR("hmd")] call FUNC(replaceEquipment)};
 
 if (_addMedical) then
 {

--- a/addons/assigngear/functions/fn_assignAIGear.sqf
+++ b/addons/assigngear/functions/fn_assignAIGear.sqf
@@ -12,6 +12,7 @@
  *   4: Boolean. (optional) Whether to add flashlights
  *   5: Boolean. (optional) Whether to force flashlights on
  *   6: Code.    (optional) Code executed on unit. unit = _this
+ *   7: Number.  (optional) AI skill, number between 1 and 0
  *
  * Return:
  * Nothing
@@ -22,7 +23,7 @@
 #include "\x\tmf\addons\assignGear\script_component.hpp"
 
 params ["_unit", "_params"];
-_params params ["_cfg", ["_useTracer", false], ["_addMedical", true], ["_addHMD", true], ["_addFlashlight", false], ["_forceFlashlight", false], ["_code", {}]];
+_params params ["_cfg", ["_useTracer", false], ["_addMedical", true], ["_addHMD", true], ["_addFlashlight", false], ["_forceFlashlight", false], ["_code", {}], ["_skill", 0.5]];
 
 LOG_2("Applied AI Loadout", str _unit, str _params);
 
@@ -97,6 +98,9 @@ _unit addEventHandler ["Reloaded", {
 
 // Grenades
 {_unit addMagazine _x} forEach (GETGEAR("grenades"));
+
+// Skill
+if !(_skill isEqualTo 0.5) then {_unit setSkill (_skill + (random 0.05) - (random 0.05))};
 
 // Code defined in unit loadout
 if !(GETGEAR("code") isEqualTo "") then

--- a/addons/assigngear/functions/fn_loadFactionCategories.sqf
+++ b/addons/assigngear/functions/fn_loadFactionCategories.sqf
@@ -21,7 +21,7 @@ params ["_control"];
 // Clear control
 lbClear _control;
 
-private _selected = get3DENSelected "object";
+private _selected = (get3DENSelected 'object' + get3DENSelected 'logic');
 private _activeFaction = "";
 if (count _selected > 0) then {
     _activeFaction = (((_selected select 0) get3DENAttribute "TMF_assignGear_faction") select 0);
@@ -37,7 +37,7 @@ private _index = -1;
 if (count _missionConfig > 0) then {
     _index = _control lbAdd "From Mission File";
     _control lbSetData [_index, "mission"];
-    
+
     {
         private _factionName = (toLower(configName _x));
         if (_factionName isEqualTo _activeFaction) exitWith {
@@ -53,11 +53,11 @@ private _activeFactionCategory = "";
 {
     private _category = getText (_x >> "category");
     if (_category isEqualTo "") then {_category = "Other";};
-    
+
     if (toLower (configName _x) == _activeFaction) then {
         _activeFactionCategory = _category;
     };
-    
+
     _factionCategories pushBackUnique _category;
 } forEach (configProperties [configFile >> "CfgLoadouts", "isClass _x"]);
 
@@ -68,7 +68,7 @@ _factionCategories sort true;
     private _index = _control lbAdd _x;
     _control lbSetData [_index,_x];
     if((!_found) and _x == _activeFactionCategory) then {
-        _found = true; 
+        _found = true;
         _control lbSetCurSel _index;
         GVAR(currentFactionCategory) = _x;
     };

--- a/addons/assigngear/functions/fn_loadFactionCategories.sqf
+++ b/addons/assigngear/functions/fn_loadFactionCategories.sqf
@@ -25,13 +25,20 @@ private _selected = (get3DENSelected 'object' + get3DENSelected 'logic');
 private _activeFaction = "";
 if (count _selected > 0) then {
     _activeFaction = (((_selected select 0) get3DENAttribute "TMF_assignGear_faction") select 0);
-    if (isNil "_activeFaction") then { _activeFaction = ""};
+    ISNILS(_activeFaction, "");
 };
 _activeFaction = toLower _activeFaction;
 
+// Check if it is loading factions for the AI loadout macro system, if so require the 'AI' class
+private _condition = if ((_selected select 0) isKindOf QGVAR(moduleLoadoutMacro)) then
+[
+    {"isClass _x && {isClass (_x >> 'AI')}"},
+    {"isClass _x"}
+];
+
 private _found = false;
 GVAR(currentFactionCategory) = "";
-private _missionConfig = (configProperties [missionConfigFile >> "CfgLoadouts","isClass _x"]);
+private _missionConfig = (configProperties [missionConfigFile >> "CfgLoadouts",_condition]);
 private _index = -1;
 
 if (count _missionConfig > 0) then {
@@ -59,7 +66,7 @@ private _activeFactionCategory = "";
     };
 
     _factionCategories pushBackUnique _category;
-} forEach (configProperties [configFile >> "CfgLoadouts", "isClass _x"]);
+} forEach (configProperties [configFile >> "CfgLoadouts", _condition]);
 
 // Sort Alphabetically.
 _factionCategories sort true;

--- a/addons/assigngear/functions/fn_loadFactions.sqf
+++ b/addons/assigngear/functions/fn_loadFactions.sqf
@@ -26,7 +26,7 @@ if (_activeFactionCategory == "") then {
 
 
 // Get the selected unit
-private _selected = get3DENSelected "object";
+private _selected = (get3DENSelected 'object' + get3DENSelected 'logic');
 private _activeFaction = "";
 if (count _selected > 0) then {
     _activeFaction = (((_selected select 0) get3DENAttribute "TMF_assignGear_faction") select 0);

--- a/addons/assigngear/functions/fn_loadFactions.sqf
+++ b/addons/assigngear/functions/fn_loadFactions.sqf
@@ -36,8 +36,12 @@ _activeFaction = toLower _activeFaction;
 
 private _factions = [];
 
-
-
+// Check if it is loading factions for the AI loadout macro system, if so require the 'AI' class
+private _condition = if ((_selected select 0) isKindOf QGVAR(moduleLoadoutMacro)) then
+[
+    {"isClass _x && {isClass (_x >> 'AI')}"},
+    {"isClass _x"}
+];
 
 private _found = false;
 
@@ -46,7 +50,7 @@ if (_activeFactionCategory == "mission") then {
     {
         private _factionName = (toLower(configName _x));
         _factions pushBackUnique [getText(_x >> "displayName"),_factionName,getText(_x >> "tooltip")];
-    } forEach (configProperties [missionConfigFile >> "CfgLoadouts","isClass _x"]);
+    } forEach (configProperties [missionConfigFile >> "CfgLoadouts",_condition]);
 
 } else {
     // Then configFile
@@ -57,7 +61,7 @@ if (_activeFactionCategory == "mission") then {
             private _factionName = (toLower(configName _x));
             _factions pushBackUnique [getText(_x >> "displayName"),_factionName,getText(_x >> "tooltip")];
         };
-    } forEach (configProperties [configFile >> "CfgLoadouts","isClass _x"]);
+    } forEach (configProperties [configFile >> "CfgLoadouts",_condition]);
 };
 
 //Alphabetical sort.

--- a/addons/assigngear/functions/fn_loadRoles.sqf
+++ b/addons/assigngear/functions/fn_loadRoles.sqf
@@ -38,9 +38,11 @@ call {
 };
 
 {
-    private _index = _control lbAdd getText(_x >> "displayName");
-    _control lbSetData [_index,configName _x];
-    _control lbSetTooltip [_index,getText(_x >> "tooltip")];
-    if(configName _x == _role) then {_control lbSetCurSel _index};
+    if (configName _x != "AI") then // Skip AI macro
+    {
+        private _index = _control lbAdd getText(_x >> "displayName");
+        _control lbSetData [_index,configName _x];
+        _control lbSetTooltip [_index,getText(_x >> "tooltip")];
+        if(configName _x == _role) then {_control lbSetCurSel _index};
+    }
 } forEach _classes;
-

--- a/addons/assigngear/functions/fn_loadRoles.sqf
+++ b/addons/assigngear/functions/fn_loadRoles.sqf
@@ -13,7 +13,7 @@
  */
 #include "\x\tmf\addons\assignGear\script_component.hpp"
 
-private _selected = get3DENSelected "object";
+private _selected = (get3DENSelected 'object' + get3DENSelected 'logic');
 _selected params [["_unit",objNull]];
 
 

--- a/addons/assigngear/functions/fn_moduleAIMacro.sqf
+++ b/addons/assigngear/functions/fn_moduleAIMacro.sqf
@@ -2,7 +2,7 @@
 
 /*
  * Name = TMF_assignGear_fnc_moduleAIMacro
- * Author = Head, Nick
+ * Author = Freddo
  *
  * Arguments:
  * Module function, do not use
@@ -11,7 +11,7 @@
  * Nothing
  *
  * Description:
- * Initializes AI gear assignment variables and assigns gear at mission start.
+ * Initialises AI gear assignment variables and assigns gear at mission start.
  */
 
 
@@ -49,5 +49,7 @@ missionNamespace setVariable [QGVAR(aiGear_) + str _side,
     _logic getVariable ["TMF_aiGear_forceFlashlight", false],
     _logic getVariable ["TMF_aiGear_code", "''"]
 ], true];
+
+LOG_1("Initialised AI Macro module ", str _module);
 
 true

--- a/addons/assigngear/functions/fn_moduleAIMacro.sqf
+++ b/addons/assigngear/functions/fn_moduleAIMacro.sqf
@@ -17,44 +17,37 @@
 
 params ["_mode", "_input"];
 
-switch _mode do {
-	// Default object init
-	case "init": {
-        _input params ["_logic", "_isActivated", "_isCuratorPlaced"];
+_input params ["_logic", "_isActivated", "_isCuratorPlaced"];
 
-        private ["_config"];
-        /*if (isClass (missionConfigFile >> "CfgLoadouts" >> _logic getVariable "TMF_aiGear_faction" >> "AI")) then
-        {
-            _config = (missionConfigFile >> "CfgLoadouts" >> _logic getVariable "TMF_aiGear_faction" >> "AI");
-        }
-        else
-        {
-            _config = (configFile >> "CfgLoadouts" >> _logic getVariable "TMF_aiGear_faction");
-        };
-        ASSERT_TRUE(isClass _config, "Loadout/macro class does not exist");
+private _TMF_aiGear_full = if ((_logic getVariable "TMF_aiGear_full") isEqualType "") then
+[
+    {call compile (_logic getVariable "TMF_aiGear_full")}, //is a string
+    {_logic getVariable "TMF_aiGear_full"} //is an array
+];
+private _faction = _TMF_aiGear_full # 1;
 
-        private _side = ((_logic getVariable "TMF_aiGear_side") call BIS_fnc_sideType);
-
-        missionNamespace setVariable [QGVAR(aiGear_) + str _side, _config, true];*/
-	};
-	// When some attributes were changed (including position and rotation)
-	case "attributesChanged3DEN": {
-		_logic = _input param [0,objNull,[objNull]];
-		// ... code here...
-	};
-	// When added to the world (e.g., after undoing and redoing creation)
-	case "registeredToWorld3DEN": {
-		_logic = _input param [0,objNull,[objNull]];
-		// ... code here...
-	};
-	// When removed from the world (i.e., by deletion or undoing creation)
-	case "unregisteredFromWorld3DEN": {
-		_logic = _input param [0,objNull,[objNull]];
-		// ... code here...
-	};
-	// "dragged3DEN" "connectionChanged3DEN"
-	default {
-
-	};
+private ["_config"];
+if (isClass (missionConfigFile >> "CfgLoadouts" >> _faction >> "AI")) then
+{
+    _config = (missionConfigFile >> "CfgLoadouts" >> _faction >> "AI");
+}
+else
+{
+    _config = (configFile >> "CfgLoadouts" >> _faction >> "AI");
 };
+ASSERT_TRUE(isClass _config, "Loadout/macro class does not exist");
+
+private _side = ((_logic getVariable "TMF_aiGear_side") call BIS_fnc_sideType);
+
+missionNamespace setVariable [QGVAR(aiGear_) + str _side,
+[
+    _config,
+    _logic getVariable ["TMF_aiGear_useTracer", false],
+    _logic getVariable ["TMF_aiGear_addMedical", true],
+    _logic getVariable ["TMF_aiGear_addHMD", true],
+    _logic getVariable ["TMF_aiGear_addFlashlight", false],
+    _logic getVariable ["TMF_aiGear_forceFlashlight", false],
+    _logic getVariable ["TMF_aiGear_code", "''"]
+], true];
+
 true

--- a/addons/assigngear/functions/fn_moduleAIMacro.sqf
+++ b/addons/assigngear/functions/fn_moduleAIMacro.sqf
@@ -17,6 +17,8 @@
 
 params ["_mode", "_input"];
 
+if (_mode in ["connectionChanged3DEN", "dragged3DEN"]) exitWith {};
+
 _input params ["_logic", "_isActivated", "_isCuratorPlaced"];
 
 private _TMF_aiGear_full = if ((_logic getVariable "TMF_aiGear_full") isEqualType "") then
@@ -51,6 +53,24 @@ missionNamespace setVariable [QGVAR(aiGear_) + str _side,
     _logic getVariable ["TMF_aiGear_skill", 0.5]
 ], true];
 
-LOG_1("Initialised AI Macro module ", str _module);
+if (_mode isEqualTo "registeredToWorld3DEN") exitWith {LOG_1("Initialised AI Macro module ", str _module);};
+
+// Apply gear in editor
+if (_mode isEqualTo "attributesChanged3DEN") then
+{
+    // attributesChanged3DEN is triggered upon module placement
+    // Skip that one time
+    if !(_logic getVariable ["TMF_aiGear_initialised", false]) exitWith
+    {
+        GVAR(XEH_unitInit) = compileFinal preprocessFileLineNumbers QPATHTOF(XEH_unitInit.sqf);
+        _logic setVariable ["TMF_aiGear_initialised", true];
+    };
+
+    {
+        [_x] call GVAR(XEH_unitInit);
+    } forEach allUnits;
+    ["AI Macro - Attributes changed, reapplying AI gear"] call BIS_fnc_3DENNotification;
+    LOG_1("Changed AI Macro attributes ", str _module);
+};
 
 true

--- a/addons/assigngear/functions/fn_moduleAIMacro.sqf
+++ b/addons/assigngear/functions/fn_moduleAIMacro.sqf
@@ -47,7 +47,8 @@ missionNamespace setVariable [QGVAR(aiGear_) + str _side,
     _logic getVariable ["TMF_aiGear_addHMD", true],
     _logic getVariable ["TMF_aiGear_addFlashlight", false],
     _logic getVariable ["TMF_aiGear_forceFlashlight", false],
-    _logic getVariable ["TMF_aiGear_code", "''"]
+    _logic getVariable ["TMF_aiGear_code", "''"],
+    _logic getVariable ["TMF_aiGear_skill", 0.5]
 ], true];
 
 LOG_1("Initialised AI Macro module ", str _module);

--- a/addons/assigngear/functions/fn_moduleAIMacro.sqf
+++ b/addons/assigngear/functions/fn_moduleAIMacro.sqf
@@ -1,0 +1,60 @@
+#include "\x\tmf\addons\assigngear\script_component.hpp"
+
+/*
+ * Name = TMF_assignGear_fnc_moduleAIMacro
+ * Author = Head, Nick
+ *
+ * Arguments:
+ * Module function, do not use
+ *
+ * Return:
+ * Nothing
+ *
+ * Description:
+ * Initializes AI gear assignment variables and assigns gear at mission start.
+ */
+
+
+params ["_mode", "_input"];
+
+switch _mode do {
+	// Default object init
+	case "init": {
+        _input params ["_logic", "_isActivated", "_isCuratorPlaced"];
+
+        private ["_config"];
+        /*if (isClass (missionConfigFile >> "CfgLoadouts" >> _logic getVariable "TMF_aiGear_faction" >> "AI")) then
+        {
+            _config = (missionConfigFile >> "CfgLoadouts" >> _logic getVariable "TMF_aiGear_faction" >> "AI");
+        }
+        else
+        {
+            _config = (configFile >> "CfgLoadouts" >> _logic getVariable "TMF_aiGear_faction");
+        };
+        ASSERT_TRUE(isClass _config, "Loadout/macro class does not exist");
+
+        private _side = ((_logic getVariable "TMF_aiGear_side") call BIS_fnc_sideType);
+
+        missionNamespace setVariable [QGVAR(aiGear_) + str _side, _config, true];*/
+	};
+	// When some attributes were changed (including position and rotation)
+	case "attributesChanged3DEN": {
+		_logic = _input param [0,objNull,[objNull]];
+		// ... code here...
+	};
+	// When added to the world (e.g., after undoing and redoing creation)
+	case "registeredToWorld3DEN": {
+		_logic = _input param [0,objNull,[objNull]];
+		// ... code here...
+	};
+	// When removed from the world (i.e., by deletion or undoing creation)
+	case "unregisteredFromWorld3DEN": {
+		_logic = _input param [0,objNull,[objNull]];
+		// ... code here...
+	};
+	// "dragged3DEN" "connectionChanged3DEN"
+	default {
+
+	};
+};
+true

--- a/addons/assigngear/functions/fn_moduleAIMacro.sqf
+++ b/addons/assigngear/functions/fn_moduleAIMacro.sqf
@@ -39,6 +39,9 @@ else
 };
 ASSERT_TRUE(isClass _config, "Loadout/macro class does not exist");
 
+_logic setVariable ["TMF_aiGear_config", _config];
+_logic setVariable ["TMF_aiGear_faction", _faction];
+
 private _side = ((_logic getVariable "TMF_aiGear_side") call BIS_fnc_sideType);
 
 missionNamespace setVariable [QGVAR(aiGear_) + str _side,
@@ -51,7 +54,7 @@ missionNamespace setVariable [QGVAR(aiGear_) + str _side,
     _logic getVariable ["TMF_aiGear_forceFlashlight", false],
     _logic getVariable ["TMF_aiGear_code", "''"],
     _logic getVariable ["TMF_aiGear_skill", 0.5]
-], true];
+]];
 
 if (_mode isEqualTo "registeredToWorld3DEN") exitWith {LOG_1("Initialised AI Macro module ", str _module);};
 

--- a/addons/assigngear/functions/fn_replaceAIWeapon.sqf
+++ b/addons/assigngear/functions/fn_replaceAIWeapon.sqf
@@ -1,0 +1,91 @@
+#include "\x\tmf\addons\assignGear\script_component.hpp"
+
+params ["_unit", "_weapon", "_scope", "_useTracer"];
+
+if (isNil "_weapon" || {_weapon isEqualTo ""}) exitWith {};
+
+_weapon = selectRandom _weapon;
+
+switch (getNumber (configFile >> "CfgWeapons" >> _weapon >> "type") ) do
+{
+    case 1: //Primary
+    {
+        _unit removeWeapon (primaryWeapon _unit);
+        if !(_useTracer) then
+        {
+            [_unit, _weapon, 3] call BIS_fnc_addWeapon;
+        } else
+        {
+            private _tracerMags = getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines") select {getNumber (configFile >> "CfgMagazines" >> _x >> "tracersEvery") == 1};
+            if (_tracerMags != []) then
+            {
+                for "_i" from 1 to 3 do
+                {
+                    _unit addMagazine (_tracerMags # 0);
+                    _unit addWeapon _weapon;
+                };
+            } else
+            {
+                [_unit, _weapon, 3] call BIS_fnc_addWeapon;
+            }
+        };
+
+        if (!isNil "_scope") then
+        {
+            // Add appropiate optics
+            switch (getText (configFile >> "CfgWeapons" >> _weapon >> "cursor")) do
+            {
+                case "arifle":
+                {
+                    // Select only optics with MRCO zoom or less
+                    private _arifleScopes = _scope select
+                    {
+                        (count ("true" configClasses (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"))) ==
+                        count ("getNumber (_x >> 'opticsZoomMin') >= 0.125" configClasses (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"));
+                    };
+                    _unit addPrimaryWeaponItem selectRandom _arifleScopes;
+                };
+                case "srifle":
+                {
+                    // Select only optics with MRCO zoom or more
+                    private _srifleScopes = _scope select
+                    {
+                        1 >= count ("getNumber (_x >> 'opticsZoomMin') <= 0.125" configClasses (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"));
+                    };
+                    if (_srifleScopes isEqualTo []) then {_srifleScopes = _scope}; //No optic found, give them anything
+                    _unit addPrimaryWeaponItem selectRandom _srifleScopes;
+                };
+                case "mg":
+                {
+                    // Select only optics with AMS zoom or less
+                    private _mgScopes = _scope select
+                    {
+                        (count ("true" configClasses (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"))) ==
+                        count ("getNumber (_x >> 'opticsZoomMin') >= 0.025" configClasses (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"));
+                    };
+                    _unit addPrimaryWeaponItem selectRandom _mgScopes;
+                };
+                default
+                {
+                    // Select only optics with holo zoom or less
+                    private _defaultScopes = _scope select
+                    {
+                        (count ("true" configClasses (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"))) ==
+                        count ("getNumber (_x >> 'opticsZoomMin') >= 0.25" configClasses (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"));
+                    };
+                    _unit addPrimaryWeaponItem selectRandom _defaultScopes;
+                };
+            };
+        };
+    };
+    case 2: //Sidearm
+    {
+        _unit removeWeapon (handgunWeapon _unit);
+        [_unit, _weapon, 3] call BIS_fnc_addWeapon;
+    };
+    case 4: //Secondary
+    {
+        _unit removeWeapon (secondaryWeapon _unit);
+        [_unit, _weapon, 2] call BIS_fnc_addWeapon;
+    };
+};

--- a/addons/assigngear/functions/fn_replaceAIWeapon.sqf
+++ b/addons/assigngear/functions/fn_replaceAIWeapon.sqf
@@ -1,15 +1,18 @@
 #include "\x\tmf\addons\assignGear\script_component.hpp"
 
-params ["_unit", "_weapon", "_scope", "_useTracer"];
+params ["_unit", "_weapon", "_params"];
+
+if (isNil "_unit" || {isNil "_weapon"}) exitWith {};
+
+if (_weapon isEqualType []) then {_weapon = selectRandom _weapon};
 
 if (isNil "_weapon" || {_weapon isEqualTo ""}) exitWith {};
-
-_weapon = selectRandom _weapon;
 
 switch (getNumber (configFile >> "CfgWeapons" >> _weapon >> "type") ) do
 {
     case 1: //Primary
     {
+        _params params ["_scope", "_useTracer"];
         _unit removeWeapon (primaryWeapon _unit);
         if !(_useTracer) then
         {
@@ -85,6 +88,20 @@ switch (getNumber (configFile >> "CfgWeapons" >> _weapon >> "type") ) do
     };
     case 4: //Secondary
     {
+        _params params ["_backpack"];
+
+        // Ensure unit has backpack
+        // TODO: add exception for disposable launchers
+        if (backpack _unit isEqualTo "" && count _backpack > 0) then
+        {
+            _backpackFiltered = _backpack select {["RPG", _x] call BIS_fnc_inString};
+            if (_backpackFiltered isEqualTo []) then
+            {
+                _backpackFiltered = _backpack select {!(_x isEqualTo "")};
+            };
+            _unit addBackpack selectRandom _backpackFiltered;
+        };
+
         _unit removeWeapon (secondaryWeapon _unit);
         [_unit, _weapon, 2] call BIS_fnc_addWeapon;
     };

--- a/addons/assigngear/functions/fn_replaceAIWeapon.sqf
+++ b/addons/assigngear/functions/fn_replaceAIWeapon.sqf
@@ -17,13 +17,13 @@ switch (getNumber (configFile >> "CfgWeapons" >> _weapon >> "type") ) do
         } else
         {
             private _tracerMags = getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines") select {getNumber (configFile >> "CfgMagazines" >> _x >> "tracersEvery") == 1};
-            if (_tracerMags != []) then
+            if !(_tracerMags isEqualTo []) then
             {
                 for "_i" from 1 to 3 do
                 {
                     _unit addMagazine (_tracerMags # 0);
-                    _unit addWeapon _weapon;
                 };
+                _unit addWeapon _weapon;
             } else
             {
                 [_unit, _weapon, 3] call BIS_fnc_addWeapon;
@@ -50,7 +50,7 @@ switch (getNumber (configFile >> "CfgWeapons" >> _weapon >> "type") ) do
                     // Select only optics with MRCO zoom or more
                     private _srifleScopes = _scope select
                     {
-                        1 >= count ("getNumber (_x >> 'opticsZoomMin') <= 0.125" configClasses (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"));
+                        1 <= count ("getNumber (_x >> 'opticsZoomMin') <= 0.125" configClasses (configFile >> "CfgWeapons" >> _x >> "ItemInfo" >> "OpticsModes"));
                     };
                     if (_srifleScopes isEqualTo []) then {_srifleScopes = _scope}; //No optic found, give them anything
                     _unit addPrimaryWeaponItem selectRandom _srifleScopes;

--- a/addons/assigngear/functions/fn_replaceAIWeapon.sqf
+++ b/addons/assigngear/functions/fn_replaceAIWeapon.sqf
@@ -1,9 +1,9 @@
 /*
  * Name = TMF_assignGear_fnc_replaceAIWeapon
- * Author = Nick
+ * Author = Freddo
  *
  * Arguments:
- * 0: Object. Unit to weapon to
+ * 0: Object. Unit to assign weapon to
  * 1: String. Weapon classname
  * 2: Array. Additional parameters, depends on weapon type
  *
@@ -11,7 +11,7 @@
  * None
  *
  * Description:
- * Dresses up a unit with the assignGear system
+ * Assigns weapon for use with the AI macro system
  */
 
 #include "\x\tmf\addons\assignGear\script_component.hpp"

--- a/addons/assigngear/functions/fn_replaceAIWeapon.sqf
+++ b/addons/assigngear/functions/fn_replaceAIWeapon.sqf
@@ -1,3 +1,19 @@
+/*
+ * Name = TMF_assignGear_fnc_replaceAIWeapon
+ * Author = Nick
+ *
+ * Arguments:
+ * 0: Object. Unit to weapon to
+ * 1: String. Weapon classname
+ * 2: Array. Additional parameters, depends on weapon type
+ *
+ * Return:
+ * None
+ *
+ * Description:
+ * Dresses up a unit with the assignGear system
+ */
+
 #include "\x\tmf\addons\assignGear\script_component.hpp"
 
 params ["_unit", "_weapon", "_params"];
@@ -12,7 +28,7 @@ switch (getNumber (configFile >> "CfgWeapons" >> _weapon >> "type") ) do
 {
     case 1: //Primary
     {
-        _params params ["_scope", "_useTracer"];
+        _params params [["_scope", []], ["_useTracer", false]];
         _unit removeWeapon (primaryWeapon _unit);
         if !(_useTracer) then
         {

--- a/addons/assigngear/functions/fn_setVoice.sqf
+++ b/addons/assigngear/functions/fn_setVoice.sqf
@@ -26,7 +26,7 @@ private _voiceArr = [];
         private _voicesetName = _x select [9];
 
         {
-            PUSH(_voiceArr, toLower _x);
+            PUSH(_voiceArr, _x);
         } forEach (uiNamespace getVariable [QGVAR(voiceset_) + _voicesetName,[]]);
     }
     else

--- a/addons/assigngear/functions/fn_setVoice.sqf
+++ b/addons/assigngear/functions/fn_setVoice.sqf
@@ -1,0 +1,43 @@
+/*
+ * Name = TMF_assignGear_fnc_setVoice
+ * Author = Freddo
+ *
+ * Arguments:
+ * 0: Object. Unit
+ * 1: ARRAY. Array of voices to choose from
+ *
+ * Return:
+ * Nothing
+ *
+ * Description:
+ * Will set a units voice to a randomly chosen one from the supplied list.
+ * Also accepts voicesets (ex. "voiceset:americanEnglish")
+ */
+ #include "\x\tmf\addons\assignGear\script_component.hpp"
+params ["_unit","_voices"];
+
+if (isNil "_unit" || isNil "_voices") exitWith {};
+
+private _voiceArr = [];
+
+{
+    if ((_x find "voiceset:") == 0) then
+    {
+        private _voicesetName = _x select [9];
+
+        {
+            PUSH(_voiceArr, toLower _x);
+        } forEach (uiNamespace getVariable [QGVAR(voiceset_) + _voicesetName,[]]);
+    }
+    else
+    {
+        PUSH(_voiceArr, toLower _x);
+    };
+} forEach _voices;
+
+if (count _voiceArr > 0) then
+{
+    private _voice = selectRandom _voiceArr;
+    [_unit,_voice] remoteExec ["setSpeaker",0,_unit];
+    _unit setSpeaker _voice;
+};

--- a/addons/assigngear/functions/fn_unitInit.sqf
+++ b/addons/assigngear/functions/fn_unitInit.sqf
@@ -1,0 +1,34 @@
+#include "\x\tmf\addons\assigngear\script_component.hpp"
+
+/*
+ * Name = TMF_assignGear_fnc_unitInit
+ * Author = Freddo
+ *
+ * Arguments:
+ * 0: Object. Unit to assign gear to
+ *
+ * Return:
+ * Boolean. If loadout was assigned then true
+ *
+ * Description:
+ * Assigns AI gear to unit if available
+ */
+
+params ["_unit"];
+
+if
+(
+    isNull _unit ||
+    {isNil (QGVAR(aiGear_) + str side _unit)} ||
+    {!local _unit} ||
+    {isPlayer _unit} ||
+    {_unit in (playableUnits + [player])} ||
+    {_unit getVariable [QGVAR(done), false]} ||
+    {_unit getVariable ["TMF_aiGear_disabled", false]}
+) exitWith {false};
+
+private _config = missionNamespace getVariable (QGVAR(aiGear_) + str side _unit);
+
+[_unit, _config] call FUNC(assignAIGear);
+
+true

--- a/addons/assigngear/loadouts/blu_f.hpp
+++ b/addons/assigngear/loadouts/blu_f.hpp
@@ -496,14 +496,14 @@ class AI
     vest[] = {"V_PlateCarrier1_rgr", "V_PlateCarrier2_rgr"};
     headgear[] = {LIST_5("H_HelmetB"), "H_HelmetB_camo", "H_HelmetB_desert", "H_HelmetB_grass", "H_HelmetB_sand", "H_HelmetB_snakeskin"};
     goggles[] = {"default"};
-    hmd[] = {};
-    backpack[] = {"none", "B_AssaultPack_rgr"};
+    hmd[] = {"NVGoggles"};
+    backpack[] = {"", "B_AssaultPack_rgr"};
     faces[] = {"faceset:african", "faceset:caucasian"};
-    voices[] = {"soundset:american"}; // TODO
+    voices[] = {"soundset:americanEnglish"};
     primaryWeapon[] = {LIST_20("arifle_MX_F"), LIST_5("arifle_MX_SW_F"), LIST_2("MMG_02_sand_F"), "srifle_DMR_03_tan_F"};
     secondaryWeapon[] = {LIST_8(""), "launch_NLAW_F"};
     sidearmWeapon[] = {LIST_5(""), "hgun_P07_F"};
-    scope[] = {"optic_holosight", LIST_5("optic_aco"), "optic_hamr"};
+    scope[] = {"optic_holosight", LIST_5("optic_aco"), "optic_hamr", "optic_ams_snd"};
     grenades[] = {"HandGrenade", "SmokeShell"};
     code = "";
 };

--- a/addons/assigngear/loadouts/blu_f.hpp
+++ b/addons/assigngear/loadouts/blu_f.hpp
@@ -497,11 +497,11 @@ class AI
     headgear[] = {LIST_5("H_HelmetB"), "H_HelmetB_camo", "H_HelmetB_desert", "H_HelmetB_grass", "H_HelmetB_sand", "H_HelmetB_snakeskin"};
     goggles[] = {"default"};
     hmd[] = {"NVGoggles"};
-    backpack[] = {"", "B_AssaultPack_rgr"};
+    backpack[] = {LIST_5(""), LIST_5("B_AssaultPack_rgr"), "B_RadioBag_01_mtp_F"};
     faces[] = {"faceset:african", "faceset:caucasian"};
     voices[] = {"voiceset:americanEnglish"};
     primaryWeapon[] = {LIST_20("arifle_MX_F"), LIST_5("arifle_MX_SW_F"), LIST_2("MMG_02_sand_F"), "srifle_DMR_03_tan_F"};
-    secondaryWeapon[] = {LIST_8(""), "launch_NLAW_F"};
+    secondaryWeapon[] = {LIST_8(""), "launch_NLAW_F", "launch_MRAWS_sand_F"};
     sidearmWeapon[] = {LIST_5(""), "hgun_P07_F"};
     scope[] = {"optic_holosight", LIST_5("optic_aco"), "optic_hamr", "optic_ams_snd"};
     grenades[] = {"HandGrenade", "SmokeShell"};

--- a/addons/assigngear/loadouts/blu_f.hpp
+++ b/addons/assigngear/loadouts/blu_f.hpp
@@ -487,3 +487,23 @@ class UAV : car
     backpack[] = {"B_UAV_01_backpack_F"};
     linkedItems[] += {"B_UavTerminal"};
 };
+
+// Special loadout used for the TMF AI Macro module
+// AI will be given one of each item randomly, ammunition will be added automatically.
+class AI
+{
+    uniform[] = {LIST_3("U_B_CombatUniform_mcam"), "U_B_CombatUniform_mcam_tshirt", "U_B_CombatUniform_mcam_vest"};
+    vest[] = {"V_PlateCarrier1_rgr", "V_PlateCarrier2_rgr"};
+    headgear[] = {LIST_5("H_HelmetB"), "H_HelmetB_camo", "H_HelmetB_desert", "H_HelmetB_grass", "H_HelmetB_sand", "H_HelmetB_snakeskin"};
+    goggles[] = {"default"};
+    hmd[] = {};
+    backpack[] = {"none", "B_AssaultPack_rgr"};
+    faces[] = {"faceset:african", "faceset:caucasian"};
+    voices[] = {"soundset:american"}; // TODO
+    primaryWeapon[] = {LIST_20("arifle_MX_F"), LIST_5("arifle_MX_SW_F"), LIST_2("MMG_02_sand_F"), "srifle_DMR_03_tan_F"};
+    secondaryWeapon[] = {LIST_8(""), "launch_NLAW_F"};
+    sidearmWeapon[] = {LIST_5(""), "hgun_P07_F"};
+    scope[] = {"optic_holosight", LIST_5("optic_aco"), "optic_hamr"};
+    grenades[] = {"HandGrenade", "SmokeShell"};
+    code = "";
+};

--- a/addons/assigngear/loadouts/blu_f.hpp
+++ b/addons/assigngear/loadouts/blu_f.hpp
@@ -499,7 +499,7 @@ class AI
     hmd[] = {"NVGoggles"};
     backpack[] = {"", "B_AssaultPack_rgr"};
     faces[] = {"faceset:african", "faceset:caucasian"};
-    voices[] = {"soundset:americanEnglish"};
+    voices[] = {"voiceset:americanEnglish"};
     primaryWeapon[] = {LIST_20("arifle_MX_F"), LIST_5("arifle_MX_SW_F"), LIST_2("MMG_02_sand_F"), "srifle_DMR_03_tan_F"};
     secondaryWeapon[] = {LIST_8(""), "launch_NLAW_F"};
     sidearmWeapon[] = {LIST_5(""), "hgun_P07_F"};

--- a/addons/assigngear/loadouts/ind_f.hpp
+++ b/addons/assigngear/loadouts/ind_f.hpp
@@ -488,3 +488,23 @@ class UAV : car
     backpack[] = {"I_UAV_01_backpack_F"};
     linkedItems[] += {"I_UavTerminal"};
 };
+
+// Special loadout used for the TMF AI Macro module
+// AI will be given one of each item randomly, ammunition will be added automatically.
+class AI
+{
+    uniform[] = {LIST_3("U_I_CombatUniform"), "U_I_CombatUniform_shortsleeve"};
+    vest[] = {LIST_2("V_PlateCarrierIA1_dgtl"), LIST_2("V_PlateCarrierIA2_dgtl"), "V_PlateCarrierIAGL_dgtl"};
+    headgear[] = {LIST_8("H_HelmetIA"), "H_MilCap_dgtl"};
+    goggles[] = {"default"};
+    hmd[] = {"NVGoggles_INDEP"};
+    backpack[] = {LIST_5(""), LIST_5("B_AssaultPack_rgr"), "B_RadioBag_01_digi_F"};
+    faces[] = {"faceset:greek"};
+    voices[] = {"voiceset:altianEnglish"};
+    primaryWeapon[] = {LIST_20("arifle_Mk20_F"), LIST_5("LMG_Mk200_F"), LIST_2("arifle_Mk20C_F"), "srifle_EBR_F"};
+    secondaryWeapon[] = {LIST_8(""), "launch_NLAW_F", "launch_MRAWS_green_rail_F"};
+    sidearmWeapon[] = {LIST_5(""), "hgun_ACPC2_F"};
+    scope[] = {"optic_holosight_blk_f", LIST_5("optic_aco_grn"), "optic_mrco", "optic_sos"};
+    grenades[] = {"HandGrenade", "SmokeShell"};
+    code = "";
+};

--- a/addons/assigngear/modules/loadoutMacro.hpp
+++ b/addons/assigngear/modules/loadoutMacro.hpp
@@ -9,7 +9,7 @@ class GVAR(moduleLoadoutMacro) : Module_F
     // Name of function triggered once conditions are met
     function = FUNC(moduleAIMacro);
     // Execution priority, modules with lower number are executed first. 0 is used when the attribute is undefined
-    functionPriority = 1;
+    functionPriority = 0;
     // 0 for server only execution, 1 for global execution, 2 for persistent global execution
     isGlobal = 0;
     // 1 to run init function in Eden Editor as well
@@ -82,7 +82,67 @@ class GVAR(moduleLoadoutMacro) : Module_F
             defaultValue = "toLower(faction _this)";
             wikiType = "[[String]]";
         };
-        class TMF_assignGear_role //Dummy
+        class TMF_aiGear_useTracer : Checkbox
+        {
+            displayName = "Use Tracer Ammo";
+            property = "TMF_aiGear_useTracer";
+            condition = "logicModule";
+            tooltip = "When assigning ammo, tracer magazines will be prioritized.";
+            defaultValue = "false";
+            wikiType = "[[Bool]]";
+        };
+        class TMF_aiGear_addMedical : Checkbox
+        {
+            displayName = "Add Medical Supplies";
+            property = "TMF_aiGear_addMedical";
+            condition = "logicModule";
+            tooltip = "Whether or not to add medical supplies to units.";
+            defaultValue = "true";
+            wikiType = "[[Bool]]";
+        };
+        class TMF_aiGear_addHMD : Checkbox
+        {
+            displayName = "Add HMD";
+            property = "TMF_aiGear_addHMD";
+            condition = "logicModule";
+            tooltip = "Whether or not to add HMDs specified in the macro.";
+            defaultValue = "true";
+            wikiType = "[[Bool]]";
+        };
+        class TMF_aiGear_addFlashlight : Checkbox
+        {
+            displayName = "Add Flashlights";
+            property = "TMF_aiGear_addFlashlight";
+            condition = "logicModule";
+            tooltip = "Whether or not to add flashlights to units if available.";
+            defaultValue = "false";
+            wikiType = "[[Bool]]";
+        };
+        class TMF_aiGear_forceFlashlight : Checkbox
+        {
+            displayName = "Force enable flashlights";
+            property = "TMF_aiGear_forceFlashlight";
+            condition = "logicModule";
+            tooltip = "Whether or not to force flashlights to be enabled.";
+            defaultValue = "false";
+            wikiType = "[[Bool]]";
+        };
+        class TMF_aiGear_code
+        {
+            displayName = "Code On Unit Created";
+            property = "TMF_aiGear_code";
+            condition = "logicModule";
+            control = "EditCodeMulti5";
+            expression = "_this setVariable ['TMF_aiGear_code',compile _value]";
+            tooltip = "Code executed on each affected unit. Unit is referenced in this code as _this.";
+            defaultValue = "''";
+            validate = "string";
+            wikiType = "[[Code]]";
+        };
+        class ModuleDescription: ModuleDescription {};
+
+
+        class TMF_assignGear_role // Dummy
         {
             property = "TMF_assignGear_role";
             displayName = "Role";
@@ -90,19 +150,19 @@ class GVAR(moduleLoadoutMacro) : Module_F
             condition = "logicModule";
             control = "None";
             //expression = "_this setVariable ['TMF_assignGear_role',_value,true];";
-            defaultValue = "'r'";
+            defaultValue = "'AI'";
             value = "''";
             wikiType = "[[String]]";
         };
-        class TMF_assignGear_full
+        class TMF_assignGear_full // Dummy
         {
             property = "TMF_assignGear_full";
             condition = "logicModule";
             control = "None";
-            expression = "_this setVariable ['TMF_assignGear_role',_value,true];"; //tmf_assignGear_fnc_helper
-            defaultValue = "['r','',false]";
+            expression = "_this setVariable ['TMF_aiGear_full',_value,true];"; //tmf_assignGear_fnc_helper
+            defaultValue = "['AI','blu_f',false]";
         };
-        class TMF_assignGear_enabled
+        class TMF_assignGear_enabled // Dummy
         {
             property = "TMF_assignGear_enabled";
             condition = "logicModule";

--- a/addons/assigngear/modules/loadoutMacro.hpp
+++ b/addons/assigngear/modules/loadoutMacro.hpp
@@ -1,0 +1,117 @@
+class GVAR(moduleLoadoutMacro) : Module_F
+{
+    // Standard object definitions
+    scope = 2; // Editor visibility; 2 will show it in the menu, 1 will hide it.
+    displayName = "AI Loadout Macro"; // Name displayed in the menu
+
+    category = "Teamwork";
+    icon = "\x\tmf\addons\common\UI\logo_tmf_small_ca.paa";
+    // Name of function triggered once conditions are met
+    function = FUNC(moduleAIMacro);
+    // Execution priority, modules with lower number are executed first. 0 is used when the attribute is undefined
+    functionPriority = 1;
+    // 0 for server only execution, 1 for global execution, 2 for persistent global execution
+    isGlobal = 0;
+    // 1 to run init function in Eden Editor as well
+    is3DEN = 1;
+
+    class Attributes : AttributesBase
+    {
+        class TMF_subcategory
+        {
+            control = "SubCategoryNoHeader2";
+            data = "AttributeSystemSubcategory";
+            description = "Module assigns gear to all AI of a side according to a macro specified in the faction. See wiki for details."; //TODO: Wiki
+            displayName = "";
+            tooltip = "";
+        };
+        class TMF_aiGear_side : Combo
+        {
+            property = "TMF_aiGear_side";
+            defaultValue = "0";
+            displayName = "Side";
+            tooltip = "Affected Side";
+            typeName = "NUMBER";
+            class Values
+            {
+                class EAST
+                {
+                    name = "Opfor";
+                    value = 0;
+                };
+                class WEST
+                {
+                    name = "Blufor";
+                    value = 1;
+                };
+                class RESISTANCE
+                {
+                    name = "Independent";
+                    value = 2;
+                };
+                class CIVILIAN
+                {
+                    name = "Civilian";
+                    value = 3;
+                };
+            };
+        };
+
+        class TMF_assignGear_side : Combo
+        {
+            /* assignGear_side was traditionally used as an attribute for storing the side in the old assign gear spec. It is now a dummy for the category.*/
+            //if (!([[1,0,1]] call EFUNC(common,checkTMFVersion))) exitWith {};
+            // getMissionConfigValue ["tmf_version",-1]
+            property = "TMF_assignGear_side";
+            displayName = "Category";
+            tooltip = "Select a faction category.";
+            condition = "logicModule";
+            control = "TMF_Side";
+            //expression = "_this setVariable ['TMF_aiGear_category',_value,true];";
+            defaultValue = "-1"; /* (side _this) call BIS_fnc_sideID;*/
+            wikiType = "[[Number]]";
+        };
+        class TMF_assignGear_faction : Combo
+        {
+            property = "TMF_assignGear_faction";
+            displayName = "Faction";
+            tooltip = "Select a faction.";
+            condition = "logicModule";
+            control = "TMF_Faction";
+            //expression = "_this setVariable ['TMF_aiGear_faction',_value,true];";
+            defaultValue = "toLower(faction _this)";
+            wikiType = "[[String]]";
+        };
+        class TMF_assignGear_role //Dummy
+        {
+            property = "TMF_assignGear_role";
+            displayName = "Role";
+            tooltip = "Select a role.";
+            condition = "logicModule";
+            control = "None";
+            //expression = "_this setVariable ['TMF_assignGear_role',_value,true];";
+            defaultValue = "'r'";
+            value = "''";
+            wikiType = "[[String]]";
+        };
+        class TMF_assignGear_full
+        {
+            property = "TMF_assignGear_full";
+            condition = "logicModule";
+            control = "None";
+            expression = "_this setVariable ['TMF_assignGear_role',_value,true];"; //tmf_assignGear_fnc_helper
+            defaultValue = "['r','',false]";
+        };
+        class TMF_assignGear_enabled
+        {
+            property = "TMF_assignGear_enabled";
+            condition = "logicModule";
+            control = "None";
+            //expression = "_this setVariable ['TMF_assignGear_enabled',_value,true];";
+            defaultValue = "true";
+            wikiType = "[[Bool]]";
+        };
+    };
+
+    class ModuleDescription: ModuleDescription {};
+};

--- a/addons/assigngear/modules/loadoutMacro.hpp
+++ b/addons/assigngear/modules/loadoutMacro.hpp
@@ -139,6 +139,17 @@ class GVAR(moduleLoadoutMacro) : Module_F
             validate = "string";
             wikiType = "[[Code]]";
         };
+        class TMF_aiGear_skill
+        {
+            displayName = "Skill Level";
+            property = "TMF_aiGear_skill";
+            condition = "logicModule";
+            control = "Skill";
+            expression = "_this setVariable ['TMF_aiGear_skill', _value]";
+            tooltip = "Overall AI Skill level.";
+            defaultValue = "0.5";
+            wikiType = "[[Number]]";
+        };
         class ModuleDescription: ModuleDescription {};
 
 

--- a/addons/autotest/CfgFunctions.hpp
+++ b/addons/autotest/CfgFunctions.hpp
@@ -3,6 +3,11 @@ class cfgFunctions {
         class COMPONENT {
             file = QPATHTO_FOLDER(functions);
             class autotest;
+            class checkExists;
+            class checkExists_faces;
+            class checkExists_insignia;
+            class checkExists_voices;
+            class testAIGear;
             class testGear;
             class testInit;
             class testEndings;

--- a/addons/autotest/functions/fn_autotest.sqf
+++ b/addons/autotest/functions/fn_autotest.sqf
@@ -10,6 +10,7 @@ _ctrlListbox lnbSetColumnsPos [0,0.05];
 // Do the tests.
 private _output = [];
 _output append ([] call FUNC(testGear));
+_output append ([] call FUNC(testAIGear));
 _output append ([] call FUNC(testInit));
 _output append ([] call FUNC(testEndings));
 
@@ -53,7 +54,6 @@ if (!((getMissionConfigValue ["respawn",0] == 1) and ("TMF_Spectator" in (getMis
         _output append _outputTest;
     }
 } forEach (configProperties [configFile >> "TMF_autoTest","isClass _x"]);
-
 
 // Display them on the auto-test UI page in Eden.
 {

--- a/addons/autotest/functions/fn_checkExists.sqf
+++ b/addons/autotest/functions/fn_checkExists.sqf
@@ -1,0 +1,24 @@
+#include "\x\tmf\addons\autotest\script_component.hpp"
+
+params ["_subarray","_config", "_faction", "_role", ["_slot", -1]];
+
+private _output = [];
+
+{
+    if ((_x != "") && (_x != "default")) then
+    {
+        if (!isClass (_config >> _x)) then
+        {
+            _output pushBack [0,format["Missing classname: %1 (for: %2 - %3)", _x,_faction,_role]];
+        }
+        else
+        {
+            if (_slot != -1 && {_slot in getArray (_config >> _x >> "type")}) then
+            {
+                _output pushBack [0,format["Incorrect weaponslot: %1 (for: %2 - %3)", _x,_faction,_role]];
+            }
+        }
+    };
+} forEach _subarray;
+
+_output

--- a/addons/autotest/functions/fn_checkExists_faces.sqf
+++ b/addons/autotest/functions/fn_checkExists_faces.sqf
@@ -1,0 +1,27 @@
+#include "\x\tmf\addons\autotest\script_component.hpp"
+
+params ["_faces", "_faction", "_role"];
+
+private _output = [];
+
+{
+    private _face = toLower _x;
+     if ((_face find "faceset:") isEqualTo 0) then
+     {
+        private _facesetName = _face select [8];
+        private _array = uiNamespace getVariable [QEGVAR(assignGear,faceset_) + _facesetName,0];
+        if (_array isEqualTo 0) then
+        {
+            _output pushBack [0,format["Invalid faceset: %1 (for: %2 - %3)", _face,_faction,_role]];
+        };
+    }
+    else
+    {
+        if (!(_face in EGVAR(assignGear,validFaces))) then
+        {
+            _output pushBack [0,format["Invalid face classname: %1 (for: %2 - %3)", _face,_faction,_role]];
+        };
+    };
+} forEach _faces;
+
+_output

--- a/addons/autotest/functions/fn_checkExists_insignia.sqf
+++ b/addons/autotest/functions/fn_checkExists_insignia.sqf
@@ -1,0 +1,15 @@
+#include "\x\tmf\addons\autotest\script_component.hpp"
+
+params ["_insignias","_faction","_role"];
+
+private _output = [];
+
+{
+    if ((_x != "") and (_x != "default")) then {
+        if !(isClass (configFile >> "CfgUnitInsignia" >> _x) || {isClass (missionConfigFile >> "CfgUnitInsignia" >> _x)}) then {
+            _output pushBack [0,format["Missing insignia classname: %1 (for: %2 - %3)", _x,_faction,_role]];
+        };
+    };
+} forEach _insignias;
+
+_output

--- a/addons/autotest/functions/fn_checkExists_voices.sqf
+++ b/addons/autotest/functions/fn_checkExists_voices.sqf
@@ -1,0 +1,27 @@
+#include "\x\tmf\addons\autotest\script_component.hpp"
+
+params ["_voices", "_faction", "_role"];
+
+private _output = [];
+
+{
+    private _voice = toLower _x;
+     if ((_voice find "voiceset:") isEqualTo 0) then
+     {
+        private _voicesetName = _voice select [9];
+        private _array = uiNamespace getVariable [QEGVAR(assignGear,voiceset_) + _voicesetName,0];
+        if (_array isEqualTo 0) then
+        {
+            _output pushBack [0,format["Invalid voiceset: %1 (for: %2 - %3)", _voice,_faction,_role]];
+        };
+    }
+    else
+    {
+        if (!(_voice in EGVAR(assignGear,validVoices))) then
+        {
+            _output pushBack [0,format["Invalid voice classname: %1 (for: %2 - %3)", _voice,_faction,_role]];
+        };
+    };
+} forEach _voices;
+
+_output

--- a/addons/autotest/functions/fn_testAIGear.sqf
+++ b/addons/autotest/functions/fn_testAIGear.sqf
@@ -1,0 +1,33 @@
+#include "\x\tmf\addons\autotest\script_component.hpp"
+
+private _output = [];
+
+{
+    private _config = (_x getVariable "TMF_aiGear_config");
+    private _faction = (_x getVariable "TMF_aiGear_faction");
+    private _role = "AI";
+
+    if (!isClass _config) then
+    {
+        _output append [0,format ["Missing AI Class", str _config]];
+    }
+    else
+    {
+        _output append ([GETGEAR("uniform"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("vest"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("backpack"), CFGVEHICLES, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("headgear"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("goggles"), CFGGLASSES, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("hmd"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("insignias"), _faction, _role] call FUNC(checkExists_insignia));
+        _output append ([GETGEAR("faces"), _faction, _role] call FUNC(checkExists_faces));
+        _output append ([GETGEAR("voices"), _faction, _role] call FUNC(checkExists_voices));
+        _output append ([GETGEAR("primaryWeapon"), CFGWEAPONS, _faction, _role, PRIMARYSLOT] call FUNC(checkExists));
+        _output append ([GETGEAR("scope"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("secondaryWeapon"), CFGWEAPONS, _faction, _role, SECONDARYSLOT] call FUNC(checkExists));
+        _output append ([GETGEAR("sidearmWeapon"), CFGWEAPONS, _faction, _role, HANDGUNSLOT] call FUNC(checkExists));
+    };
+
+} forEach (allMissionObjects "TMF_assignGear_moduleLoadoutMacro");
+
+_output

--- a/addons/autotest/functions/fn_testEndings.sqf
+++ b/addons/autotest/functions/fn_testEndings.sqf
@@ -12,9 +12,9 @@ if (_count != 3) exitWith {}; //default template
 
 while {_i < _count} do {
     if (configName (_config select _i) == "CustomEnding1") exitWith {
-        _output pushBack [1,"CustomEnding1 is still present. Mission endings are probably not configured."];  
+        _output pushBack [1,"CustomEnding1 is still present. Mission endings are probably not configured."];
     };
     _i = _i + 1;
 };
 
-_output;
+_output

--- a/addons/autotest/functions/fn_testGear.sqf
+++ b/addons/autotest/functions/fn_testGear.sqf
@@ -11,8 +11,6 @@ private _cfgMagazines = configFile >> "CfgMagazines";
 
 private _output = [];
 
-#define GETGEAR(var) [_config >> var] call CFUNC(getCfgEntryFromPath)
-
 private _fnc_checkExists = {
     params ["_subarray","_config"];
     

--- a/addons/autotest/functions/fn_testGear.sqf
+++ b/addons/autotest/functions/fn_testGear.sqf
@@ -2,154 +2,98 @@
 //
 #include "\x\tmf\addons\autotest\script_component.hpp"
 
-
-private _cfgWeapons = configFile >> "CfgWeapons";
-private _cfgVehicles = configFile >> "CfgVehicles";
-private _cfgGlasses = configFile >> "CfgGlasses";
-private _cfgMagazines = configFile >> "CfgMagazines";
-
-
 private _output = [];
-
-private _fnc_checkExists = {
-    params ["_subarray","_config"];
-    
-    {
-        if ((_x != "") and (_x != "default")) then {
-            if (!isClass (_config >> _x)) then {
-                _output pushBack [0,format["Missing classname: %1 (for: %2 - %3)", _x,_faction,_role]];  
-            };
-        };
-    } forEach _subarray;
-};
-
-private _fnc_checkExists_insignia = {
-    params ["_insignias"];
-    
-    {
-        if ((_x != "") and (_x != "default")) then {
-            if !(isClass (configFile >> "CfgUnitInsignia" >> _x) || {isClass (missionConfigFile >> "CfgUnitInsignia" >> _x)}) then {
-                _output pushBack [0,format["Missing insignia classname: %1 (for: %2 - %3)", _x,_faction,_role]];  
-            };
-        };
-    } forEach _insignias;
-};
 
 private _fncTestUnit = {
     params ["_faction",["_role","r"]];
 
     private _config = missionConfigFile >> "cfgLoadouts" >> _faction >> _role;
-    if (!isClass (_config)) then { 
+    if (!isClass (_config)) then {
         _config = configFile >> "cfgLoadouts" >> _faction >> _role;
     };
     private _return = [0,0,0];
     if (isClass _config) then {
-        private _uniform = GETGEAR("uniform"); //CfgWeapons
-        [_uniform, _cfgWeapons] call _fnc_checkExists;
-        private _vest = GETGEAR("vest"); //CfgWeapons
-        [_vest, _cfgWeapons] call _fnc_checkExists;
-        private _backpack = GETGEAR("backpack"); /// cfghivecles
-        [_backpack, _cfgVehicles] call _fnc_checkExists;
-        private _headgear = GETGEAR("headgear"); //CfgWeapons
-        [_headgear, _cfgWeapons] call _fnc_checkExists;
-        private _goggles = GETGEAR("goggles"); //CfgWeapons
-        [_goggles, _cfgGlasses] call _fnc_checkExists;
-        private _hmd = GETGEAR("hmd"); // "CfgGlasses"
-        [_hmd, _cfgWeapons] call _fnc_checkExists;
 
-        private _insignias = GETGEAR("insignias"); // "CfgUnitInsignia"
-        [_insignias] call _fnc_checkExists_insignia;
+        // Check Equipment
+        _output append ([GETGEAR("uniform"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("vest"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("backpack"), CFGVEHICLES, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("headgear"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("goggles"), CFGGLASSES, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("hmd"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("insignias"), _faction, _role] call FUNC(checkExists_insignia));
+        _output append ([GETGEAR("faces"), _faction, _role] call FUNC(checkExists_faces));
 
-        // Test faces;
-        private _faces = GETGEAR("faces");
-        private _validFaces = uiNamespace getVariable ["tmf_assignGear_validFaces",[]];
+        // Check Primary Weapon
+        _output append ([GETGEAR("primaryWeapon"), CFGWEAPONS, _faction, _role, PRIMARYSLOT] call FUNC(checkExists));
+        _output append ([GETGEAR("scope"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("bipod"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("attachment"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
+        _output append ([GETGEAR("silencer"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
 
-        {
-            private _face = toLower _x;
-             if ((_face find "faceset:") isEqualTo 0) then {
-                private _facesetName = _face select [8];
-                private _array = uiNamespace getVariable ["tmf_assignGear_faceset_" + _facesetName,0];
-                if (_array isEqualTo 0) then {
-                     _output pushBack [0,format["Invalid faceset: %1 (for: %2 - %3)", _face,_faction,_role]];  
-                };
-            } else {
-                if (!(_face in _validFaces)) then {
-                    _output pushBack [0,format["Invalid face classname: %1 (for: %2 - %3)", _face,_faction,_role]];  
-                };
-            };
-        } forEach _faces;
+        // Check Secondary Weapon
+        _output append ([GETGEAR("secondaryWeapon"),CFGWEAPONS, _faction, _role, SECONDARYSLOT] call FUNC(checkExists));
+        _output append ([GETGEAR("secondaryAttachments"),CFGWEAPONS, _faction, _role] call FUNC(checkExists));
 
-        // Get primary weapon and items
-        private _primaryWeapon = GETGEAR("primaryWeapon"); //CfgWeapons"
-        [_primaryWeapon, _cfgWeapons] call _fnc_checkExists;
-        private _scope = GETGEAR("scope"); // "CfgWeapons"
-        [_scope, _cfgWeapons] call _fnc_checkExists;
-        private _bipod = GETGEAR("bipod"); //"CfgWeapons"
-        [_bipod, _cfgWeapons] call _fnc_checkExists;
-        private _attachment = GETGEAR("attachment"); // "CfgWeapons"
-        [_attachment, _cfgWeapons] call _fnc_checkExists;
-        private _silencer = GETGEAR("attachment"); //"CfgWeapons"
-        [_silencer, _cfgWeapons] call _fnc_checkExists;
+        // Check Sidearm Weapon
+        _output append ([GETGEAR("sidearmWeapon"),CFGWEAPONS, _faction, _role, HANDGUNSLOT] call FUNC(checkExists));
+        _output append ([GETGEAR("sidearmAttachments"),CFGWEAPONS, _faction, _role] call FUNC(checkExists));
 
-        // Get other weapon and items
-        private _secondaryWeapon = GETGEAR("secondaryWeapon"); //CfgWeapons"
-        [_secondaryWeapon, _cfgWeapons] call _fnc_checkExists;
-        private _secondaryAttachments = GETGEAR("secondaryAttachments");//"CfgWeapons"
-        [_secondaryAttachments, _cfgWeapons] call _fnc_checkExists;
-        private _sidearmWeapon = GETGEAR("sidearmWeapon"); //CfgWeapons"
-        [_sidearmWeapon, _cfgWeapons] call _fnc_checkExists;
-        private _sidearmAttachments = GETGEAR("sidearmAttachments");//"CfgWeapons"
-        [_sidearmAttachments, _cfgWeapons] call _fnc_checkExists;
+        // Linked "weapons"/items
+        _output append ([GETGEAR("linkedItems"), CFGWEAPONS, _faction, _role] call FUNC(checkExists));
 
-        private _linkedItems = GETGEAR("linkedItems");// "Cfgmagazines"
-        [_linkedItems, _cfgWeapons] call _fnc_checkExists;
-        
         // Get items in inventory
         // CfgWeapons >> "weaponName" >> WeaponSlotsInfo >> mass
         // CfgWeapons >> ItemName >> ItemInfo >> mass
         //TODO: factor in allowedSlots - 701 vest, 801 uniform, 901 backpacks
 
+
+        // Select smallest containers
+
         private _freeBackpackSpace = -1;
-        // select smallest.
+        private _backpack = GETGEAR("backpack");
         if (count _backpack > 0) then {
             private _sizes = _backpack apply {getContainerMaxLoad _x};
             _sizes sort true;
-            _freeBackpackSpace = _sizes select 0;
+            _freeBackpackSpace = (_sizes # 0);
         };
         private _freeUniformSpace = -1;
+        private _uniform = GETGEAR("uniform");
         if (count _uniform > 0) then {
             private _sizes = _uniform apply {getContainerMaxLoad _x};
             _sizes sort true;
-            _freeUniformSpace = _sizes select 0;
+            _freeUniformSpace = (_sizes # 0);
         };
+
+        private _vest = GETGEAR("vest");
         private _freeVestSpace = -1;
         if (count _vest > 0) then {
             private _sizes = _vest apply {getContainerMaxLoad _x};
             _sizes sort true;
-            _freeVestSpace = _sizes select 0;
+            _freeVestSpace = (_sizes # 0);
         };
         private _mags = []; // For checking number compatible
 
         {
             private _mass = -1;
             call {
-                if (isClass (_cfgMagazines >> _x)) exitWith {
-                    _mass = getNumber (_cfgMagazines >> _x >> "mass");
-                    _mags pushBack (toLower _x);
+                if (isClass (CFGMAGAZINES >> _x)) exitWith {
+                    _mass = getNumber (CFGMAGAZINES >> _x >> "mass");
+                    PUSH(_mags,toLower _x);
                 };
-                if (isClass (_cfgWeapons >> _x)) exitWith {
-                    _mass = getNumber (_CfgWeapons >> _x >> "ItemInfo" >> "mass");
+                if (isClass (CFGWEAPONS >> _x)) exitWith {
+                    _mass = getNumber (CFGWEAPONS >> _x >> "ItemInfo" >> "mass");
                     if (_mass isEqualTo 0) then {
-                        _mass = getNumber (_CfgWeapons >> _x >> "WeaponSlotsInfo" >> "mass");
+                        _mass = getNumber (CFGWEAPONS >> _x >> "WeaponSlotsInfo" >> "mass");
                     };
                 };
-                if (isClass (_cfgGlasses >> _x)) exitWith {
-                    _mass = getNumber (_cfgGlasses >> _x >> "mass");
+                if (isClass (CFGGLASSES >> _x)) exitWith {
+                    _mass = getNumber (CFGGLASSES >> _x >> "mass");
                 };
             };
             if (_mass >= 0) then {
                 if (_mass <= _freeBackpackSpace) then {
-                    _freeBackpackSpace = _freeBackpackSpace - _mass;
+                    SUB(_freeBackpackSpace,_mass);
                 } else {
                     _output pushBack [0,format["'%1' won't fit in backpack (for: %2 - %3)", _x,_faction,_role]];
                 };
@@ -160,28 +104,28 @@ private _fncTestUnit = {
 
         private _magsAndItems = (GETGEAR("magazines")) + (GETGEAR("items"));
 
-        
+
         {
             private _mass = -1;
-            if (isClass (_cfgMagazines >> _x)) then {
-                _mass = getNumber (_cfgMagazines >> _x >> "mass");
-                _mags pushBack (toLower _x);
+            if (isClass (CFGMAGAZINES >> _x)) then {
+                _mass = getNumber (CFGMAGAZINES >> _x >> "mass");
+                PUSH(_mags,toLower _x);
             };
-            if (isClass (_cfgWeapons >> _x)) then {
-                _mass = getNumber (_CfgWeapons >> _x >> "ItemInfo" >> "mass");
+            if (isClass (CFGWEAPONS >> _x)) then {
+                _mass = getNumber (CFGWEAPONS >> _x >> "ItemInfo" >> "mass");
                 if (_mass isEqualTo 0) then {
-                    _mass = getNumber (_CfgWeapons >> _x >> "WeaponSlotsInfo" >> "mass");
+                    _mass = getNumber (CFGWEAPONS >> _x >> "WeaponSlotsInfo" >> "mass");
                 };
             };
             if (_mass >= 0) then {
                 if (_mass <= _freeUniformSpace) then {
-                    _freeUniformSpace = _freeUniformSpace - _mass;
+                    SUB(_freeUniformSpace,_mass);
                 } else {
                     if (_mass <= _freeVestSpace) then {
-                        _freeVestSpace = _freeVestSpace - _mass;
+                        SUB(_freeVestSpace,_mass);
                     } else {
                         if (_mass <= _freeBackpackSpace) then {
-                            _freeBackpackSpace = _freeBackpackSpace - _mass;
+                            SUB(_freeBackpackSpace,_mass);
                         } else {
                             _output pushBack [0,format["'%1' won't fit (for: %2 - %3)", _x,_faction,_role]];
                         };
@@ -192,22 +136,22 @@ private _fncTestUnit = {
             };
         } forEach _magsAndItems;
 
-        //Mag check 
+        //Mag check
         if (count _primaryWeapon > 0) then {
-            private _weaponMags = [_primaryWeapon select 0] call CBA_fnc_compatibleMagazines;
-            _weaponMags = _weaponMags apply {toLower _x};
+            private _weaponMags = [_primaryWeapon # 0] call CBA_fnc_compatibleMagazines;
+            MAP(_weaponMags,toLower _x);
             private _weaponMagCount = {_x in _weaponMags} count _mags;
             if (_weaponMagCount < 3) then {
-                _output pushBack [1,format["Role: %2 - %3 has less than 3 compatible mags for primary weapon.", _x,_faction,_role]]; 
+                _output pushBack [1,format["Role: %2 - %3 has less than 3 compatible mags for primary weapon.", _x,_faction,_role]];
             };
         };
-        
+
         if (count _sidearmWeapon > 0) then {
-            private _weaponMags = [_sidearmWeapon select 0] call CBA_fnc_compatibleMagazines;
-            _weaponMags = _weaponMags apply {toLower _x};
+            private _weaponMags = [_sidearmWeapon # 0] call CBA_fnc_compatibleMagazines;
+            MAP(_weaponMags,toLower _x);
             private _weaponMagCount = {_x in _weaponMags} count _mags;
             if (_weaponMagCount == 0) then {
-                _output pushBack [1,format["Role: %2 - %3 has no compatible mag for sidearm.", _x,_faction,_role]]; 
+                _output pushBack [1,format["Role: %2 - %3 has no compatible mag for sidearm.", _x,_faction,_role]];
             };
         };
 
@@ -229,12 +173,12 @@ private _loadoutFreespace = [];
     if (_enabled) then {
         (_unit get3DENAttribute 'TMF_assignGear_role') params [["_role","r"]];
         (_unit get3DENAttribute 'TMF_assignGear_faction') params [["_faction",toLower(faction _unit)]];
-        
+
         private _index = _loadoutsTested pushBackUnique [_faction, _role];
         private _freespace = []; // Uniform,Vest,Backpack;
         if (_index != -1) then {
             _freespace = [_faction,_role] call _fncTestUnit;
-            _loadoutFreespace pushBack _freespace;
+            PUSH(_loadoutFreespace,_freespace);
             _unit call EFUNC(assigngear,assignGear);
             private _weight = (loadAbs _unit) * 0.1;
             _weight = (round (_weight * (1/2.2046) * 100)) / 100; // ACE calculation
@@ -248,25 +192,25 @@ private _loadoutFreespace = [];
         _freespace params ["_freeUniformSpace","_freeVestSpace","_freeBackpackSpace"];
         {
             private _mass = -1;
-            if (isClass (_cfgMagazines >> _x)) then {
-                _mass = getNumber (_cfgMagazines >> _x >> "mass");
-                _mags pushBack (toLower _x);
+            if (isClass (CFGMAGAZINES >> _x)) then {
+                _mass = getNumber (CFGMAGAZINES >> _x >> "mass");
+                PUSH(_mags,toLower _x);
             };
-            if (isClass (_cfgWeapons >> _x)) then {
-                _mass = getNumber (_CfgWeapons >> _x >> "ItemInfo" >> "mass");
+            if (isClass (CFGWEAPONS >> _x)) then {
+                _mass = getNumber (CFGWEAPONS >> _x >> "ItemInfo" >> "mass");
                 if (_mass isEqualTo 0) then {
-                    _mass = getNumber (_CfgWeapons >> _x >> "WeaponSlotsInfo" >> "mass");
+                    _mass = getNumber (CFGWEAPONS >> _x >> "WeaponSlotsInfo" >> "mass");
                 };
             };
             if (_mass >= 0) then {
                 if (_mass <= _freeUniformSpace) then {
-                    _freeUniformSpace = _freeUniformSpace - _mass;
+                    SUB(_freeUniformSpace,_mass);
                 } else {
                     if (_mass <= _freeVestSpace) then {
-                        _freeVestSpace = _freeVestSpace - _mass;
+                        SUB(_freeVestSpace,_mass);
                     } else {
                         if (_mass <= _freeBackpackSpace) then {
-                            _freeBackpackSpace = _freeBackpackSpace - _mass;
+                            SUB(_freeBackpackSpace,_mass);
                         } else {
                             _output pushBack [0,format["'%1' radio won't fit for: %2 (%3)", _x,_unit,group _unit]];
                         };
@@ -279,10 +223,6 @@ private _loadoutFreespace = [];
     };
 } forEach allUnits;
 
-
-
-
-
 _output pushBack [-1,"AssignGear checks complete."];
 
-_output;
+_output

--- a/addons/autotest/script_component.hpp
+++ b/addons/autotest/script_component.hpp
@@ -3,6 +3,8 @@
 #include "\x\tmf\addons\main\script_mod.hpp"
 #include "\x\tmf\addons\main\script_macros.hpp"
 
+#define GETGEAR(var) [_config >> var] call CFUNC(getCfgEntryFromPath)
+
 #define ERROR 0
 #define PASS -1
 #define WARNING 1

--- a/addons/autotest/script_component.hpp
+++ b/addons/autotest/script_component.hpp
@@ -5,6 +5,15 @@
 
 #define GETGEAR(var) [_config >> var] call CFUNC(getCfgEntryFromPath)
 
+#define CFGWEAPONS (configFile >> "CfgWeapons")
+#define CFGVEHICLES (configFile >> "CfgVehicles")
+#define CFGGLASSES (configFile >> "CfgGlasses")
+#define CFGMAGAZINES (configFile >> "CfgMagazines")
+
+#define PRIMARYSLOT 1
+#define HANDGUNSLOT 2
+#define SECONDARYSLOT 4
+
 #define ERROR 0
 #define PASS -1
 #define WARNING 1

--- a/tools/sqf_validator.py
+++ b/tools/sqf_validator.py
@@ -83,8 +83,8 @@ def check_sqf_syntax(filepath):
                         if (c == '"' or c == "'"):
                             isInString = True
                             inStringType = c
-                        elif (c == '#'):
-                            ignoreTillEndOfLine = True
+                        elif (c == '#'): # Since 1.82 can be used as an alternative to select
+                            ignoreTillEndOfLine = False
                         elif (c == '/'):
                             checkIfInComment = True
                         elif (c == '('):


### PR DESCRIPTION
### Purpose
The purpose of this system is to add an easy lazy way to bulk-add loadouts to AI units, and also have them apply to Zeus spawned units which is a limitation with the current, manual gear assignment system.

### Brief explanation
The way this system works is that it utilizes a new special class in cfgLoadouts called `class AI`, which the system randomly picks gear from and assigns it. Weapons are automatically assigned ammunition, with an optional parameter to prioritize tracer ammo.

This allows for easily defining multiple weapons that use differing ammunition types, and have it automatically pick out the ammunition without needing it defined.  
On the topic of ammunition, the AI are only given small amounts of magazines, but are given eventhandlers that give them new magazines when reloading to compensate for not being able to pick up gear. This may help combat players picking up random AI equipment.

Additionally, fnc_setVoice and voicesets have been added to not have for example russian units speak farsi or similar. Currently only vanilla voices have been added.

<details>
<summary>Example Config Class</summary>

```hpp
class AI
{
    uniform[] = {LIST_3("U_B_CombatUniform_mcam"), "U_B_CombatUniform_mcam_tshirt", "U_B_CombatUniform_mcam_vest"};
    vest[] = {"V_PlateCarrier1_rgr", "V_PlateCarrier2_rgr"};
    headgear[] = {LIST_5("H_HelmetB"), "H_HelmetB_camo", "H_HelmetB_desert", "H_HelmetB_grass", "H_HelmetB_sand", "H_HelmetB_snakeskin"};
    goggles[] = {"default"};
    hmd[] = {"NVGoggles"};
    backpack[] = {"", "B_AssaultPack_rgr"};
    faces[] = {"faceset:african", "faceset:caucasian"};
    voices[] = {"voiceset:americanEnglish"};
    primaryWeapon[] = {LIST_20("arifle_MX_F"), LIST_5("arifle_MX_SW_F"), LIST_2("MMG_02_sand_F"), "srifle_DMR_03_tan_F"};
    secondaryWeapon[] = {LIST_8(""), "launch_NLAW_F"};
    sidearmWeapon[] = {LIST_5(""), "hgun_P07_F"};
    scope[] = {"optic_holosight", LIST_5("optic_aco"), "optic_hamr", "optic_ams_snd"};
    grenades[] = {"HandGrenade", "SmokeShell"};
    code = "";
};
```
</details>

<details>
<summary>Module attributes</summary>

![AI loadout macro](https://user-images.githubusercontent.com/14627848/66229260-c34acc80-e6e1-11e9-9283-c424b8042c08.PNG)

</details>

### TODO

- [x] Add skill slider
- [x] Fix compatibility with Wavespawners
- [x] Hide macro class from role assignment
- [ ] Test in MP and Dedicated environments
- [x] Preview loadout in editor
- [x] Fix compatibility with Autotest
- [ ] Wiki documentation
- [x] Add checkbox option to skip units

### Credits
@jameslkingsley for inspiration and concept from his implementation in https://github.com/ARCOMM/ARCORE
@Sniperhid for helping me with Controls and Attributes