### PR TITLE
Sort out Garrison on Headless Clients

### DIFF
--- a/addons/ai/CfgEventHandlers.hpp
+++ b/addons/ai/CfgEventHandlers.hpp
@@ -1,0 +1,6 @@
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE( call COMPILE_FILE(XEH_postInit) );
+    };
+};

--- a/addons/ai/XEH_postInit.sqf
+++ b/addons/ai/XEH_postInit.sqf
@@ -1,0 +1,15 @@
+#include "\x\tmf\addons\AI\script_component.hpp"
+// Intended for Server and HCs.
+
+if (hasInterface) exitWith {};
+
+// Hotfix for: DisableAi not being populated everywhere.
+["CAManBase", "init", {
+    (_this select 0) addEventHandler ["Local",{
+        params ["_entity", "_isLocal"];
+        if (_isLocal && {(group _entity) getVariable [QGVAR(garrisonGroup),false]}) then {
+            _entity disableAI "Path";
+            _entity setUnitPos "UP";
+        };
+    }];
+},true,[],true] call CBA_fnc_addClassEventHandler;

--- a/addons/ai/config.cpp
+++ b/addons/ai/config.cpp
@@ -15,6 +15,7 @@ class cfgPatches
     };
 };
 
+#include "CfgEventHandlers.hpp"
 #include "CfgFunctions.hpp"
 #include "CfgWaypoints.hpp"
 #include "CfgModules.hpp"

--- a/addons/ai/functions/fn_garrison.sqf
+++ b/addons/ai/functions/fn_garrison.sqf
@@ -31,6 +31,7 @@ private _debug = _logic getVariable ["Debug",false];
 private _areas = (synchronizedObjects _logic) select {side _x == sideLogic && _x isKindOf QGVAR(area)};
 private _unitData = _logic getVariable [QGVAR(unitData),[]];
 private _mainGroup = createGroup ((_unitData select 0) select 0);
+[_mainGroup,QGVAR(garrisonGroup),true] call tmf_common_fnc_initGroupVar;
 private _holdPos = _logic getVariable ["hold", false];
 
 if(count _areas > 0) then {

--- a/addons/ai/functions/fn_garrisonQuantity.sqf
+++ b/addons/ai/functions/fn_garrisonQuantity.sqf
@@ -33,6 +33,7 @@ private _areas = (synchronizedObjects _logic) select {side _x == sideLogic && _x
 _areas pushBack _logic; // Add the garrison module as viable area.
 private _unitData = _logic getVariable [QGVAR(unitData),[]];
 private _mainGroup = createGroup ((_unitData select 0) select 0);
+[_mainGroup,QGVAR(garrisonGroup),true] call tmf_common_fnc_initGroupVar;
 private _holdPos = _logic getVariable ["hold", false];
 
 private _buildings = [];


### PR DESCRIPTION
**What this pull request does**
- EnableAI/DisableAI effects do not broadcast. This is problem when AI are transfered particularly when garrisioned, as they may abandon their posts. This didn't happen all the time.
- For Garrison only this will set the AI flags when unit ownership is transfered (event driven).