### PR TITLE
Feature: #loadout command

### DIFF
--- a/addons/assigngear/CfgEventHandlers.hpp
+++ b/addons/assigngear/CfgEventHandlers.hpp
@@ -3,3 +3,9 @@ class Extended_PreStart_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_preStart));
     };
 };
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/addons/assigngear/CfgFunctions.hpp
+++ b/addons/assigngear/CfgFunctions.hpp
@@ -13,6 +13,7 @@ class cfgFunctions {
             class replacePrimaryWeapon;
             class replaceSecondaryWeapon;
             class replaceSidearmWeapon;
+            class chat_loadout;
             class gearSelector;
             class helper;
             class saveRole;

--- a/addons/assigngear/CfgFunctions.hpp
+++ b/addons/assigngear/CfgFunctions.hpp
@@ -13,6 +13,7 @@ class cfgFunctions {
             class replacePrimaryWeapon;
             class replaceSecondaryWeapon;
             class replaceSidearmWeapon;
+            class gearSelector;
             class helper;
             class saveRole;
             class setFace;
@@ -20,5 +21,14 @@ class cfgFunctions {
             class onEdenMessageRecieved;
             class onEdenMissionChange;
         };
+        class DOUBLES(COMPONENT,gui) {
+            file = QPATHTO_FOLDER(gui);
+            class gui_gearSelector_init;
+            class gui_gearSelector_loadFactions;
+            class gui_gearSelector_loadCategories;
+            class gui_gearSelector_loadRoles;
+            class gui_gearSelector_random;
+            class gui_gearSelector_submit;
+        }
     };
 };

--- a/addons/assigngear/XEH_preInit.sqf
+++ b/addons/assigngear/XEH_preInit.sqf
@@ -1,3 +1,5 @@
 #include "script_component.hpp"
 
-["loadout",FUNC(chat_loadout), "all"] call CBA_fnc_registerChatCommand;
+#include "initSettings.sqf"
+
+#include "initCommands.sqf"

--- a/addons/assigngear/XEH_preInit.sqf
+++ b/addons/assigngear/XEH_preInit.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+["loadout",FUNC(chat_loadout), "all"] call CBA_fnc_registerChatCommand;

--- a/addons/assigngear/config.cpp
+++ b/addons/assigngear/config.cpp
@@ -1,4 +1,6 @@
 #include "script_component.hpp"
+#include "\a3\3den\UI\macros.inc"
+#include "\a3\3DEN\UI\macroexecs.inc"
 
 class cfgPatches
 {
@@ -14,7 +16,16 @@ class cfgPatches
         VERSION_CONFIG;
     };
 };
+class RscStandardDisplay;
+class RscText;
+class RscTitle;
+class RscCombo;
 class RscButtonMenu;
+class RscButtonMenuCancel: RscButtonMenu {};
+class RscButtonMenuOK: RscButtonMenu {};
+class RscBackgroundGUI;
+class RscBackgroundGUITop;
+class RscPicture;
 class RscDisplayArsenal
 {
    class controls
@@ -35,4 +46,4 @@ class RscDisplayArsenal
 #include "Cfg3DEN.hpp"
 #include "CfgFaceSets.hpp"
 #include "display3DEN.hpp"
-
+#include "gui\gearSelector.hpp"

--- a/addons/assigngear/functions/fn_chat_loadout.sqf
+++ b/addons/assigngear/functions/fn_chat_loadout.sqf
@@ -1,0 +1,89 @@
+/*
+ * Name = TMF_assignGear_fnc_chat_loadout
+ * Author = Freddo
+ *
+ * Command syntaxes:
+ * #loadout                  - Opens RscGearSelector
+ * #loadout <role>           - Assigns role from current faction
+ * #loadout <player>         - Copies loadout from other player
+ * #loadout <faction> <role> - Assigns role from defined faction
+ *
+ * Description:
+ * Opens up the RscGearSelector interface,
+ * assigns a loadout,
+ * or copies another players loadout
+ *
+ * Return:
+ * None
+ */
+
+#include "\x\tmf\addons\assignGear\script_component.hpp"
+
+params ["_input"];
+
+private _inputArr = _input splitString " ";
+
+private _fnc_findMatch = {
+    params ["_name"];
+
+    private _matches = [];
+
+    {
+        if ([_name, name _x] call BIS_fnc_inString) then {
+            _matches pushBack _x;
+        };
+    } forEach ([] call CBA_fnc_players);
+
+    if (count _matches == 1) exitWith {_matches select 0};
+    objNull
+};
+
+switch (count _inputArr) do {
+    case 0: FUNC(gearSelector);
+    case 1: {
+        _inputArr params ["_in1"];
+
+        private _faction = player getVariable [QGVAR(faction), ""];
+        private _cfg = if (isClass (missionConfigFile >> "CfgLoadouts" >> _faction >> _in1)) then [{missionConfigFile}, {configFile}];
+        if (isClass (_cfg >> "CfgLoadouts" >> _faction >> _in1)) then {
+            // Input corresponds with a loadout
+            [player, _faction, _in1] call FUNC(assignGear);
+            systemChat format ["TMF: Assigned loadout %1", str getText (_cfg >> "CfgLoadouts" >> _faction >> _in1 >> "displayName")];
+        } else {
+            private _match = [_in1] call _fnc_findMatch;
+            if (isNull _match) then {
+                // No loadout or player found, or more than one player
+                if (_faction isEqualTo "") then {
+                    systemChat FORMAT_1("TMF Error: Cannot select loadout as you do not have an assigned faction. Use #loadout <faction> <role>");
+                    systemChat FORMAT_1("TMF Error: Could not find player containing %1, or more than one player found.", str _in1);
+                } else {
+                    systemChat FORMAT_1("TMF Error: No loadout with name %1 in %2", str _in1, _faction);
+                    systemChat FORMAT_1("TMF Error: Could not find player containing %1, or more than one player found.", str _in1);
+                };
+            } else {
+                // Copy other players loadout
+                player setUnitLoadout getUnitLoadout _match;
+                systemChat FORMAT_1("TMF: Copied loadout from %1", name _match);
+            };
+        };
+    };
+    case 2: {
+        _inputArr params ["_in1", "_in2"];
+
+        private _cfg = if (isClass (missionConfigFile >> "CfgLoadouts" >> _in1 >> _in1)) then [{missionConfigFile}, {configFile}];
+        if (isClass (_cfg >> "CfgLoadouts" >> _in1 >> _in2)) then {
+            // Input corresponds with a loadout
+            [player, _in1, _in2] call FUNC(assignGear);
+            systemChat FORMAT_2("TMF: Assigned loadout %1 from %2", \
+                str getText (_cfg >> "CfgLoadouts" >> _in1 >> _in2 >> "displayName"), \
+                str getText (_cfg >> "CfgLoadouts" >> _in1 >> "displayName")
+            );
+        } else {
+            if !(isClass (_cfg >> "CfgLoadouts" >> _in1)) then {
+                systemChat FORMAT_1("TMF Error: No faction with name %1", str _in1);
+            } else {
+                systemChat FORMAT_2("TMF Error: No loadout with name %1 in %2", str _in2, str _in1);
+            };
+        };
+    };
+};

--- a/addons/assigngear/functions/fn_gearSelector.sqf
+++ b/addons/assigngear/functions/fn_gearSelector.sqf
@@ -1,0 +1,16 @@
+/*
+ * Name = TMF_assignGear_fnc_gearSelector
+ * Author = Bear, Freddo
+ *
+ * Arguments:
+ * None
+ *
+ * Return:
+ * None
+ *
+ * Description:
+ * Opens up a player loadout selection interface.
+ */
+#include "\x\tmf\addons\assignGear\script_component.hpp"
+
+createDialog QGVAR(RscGearSelector);

--- a/addons/assigngear/gui/fn_gui_gearSelector_init.sqf
+++ b/addons/assigngear/gui/fn_gui_gearSelector_init.sqf
@@ -1,0 +1,21 @@
+#include "\x\tmf\addons\assignGear\script_component.hpp"
+
+disableSerialization;
+params ["_display"];
+
+private _playerRole = player getVariable [QGVAR(role), "r"];
+private _playerFaction = player getVariable [QGVAR(faction), faction player];
+
+if !(isClass (missionConfigFile >> "CfgLoadouts" >> _playerFaction) || isClass (configFile >> "CfgLoadouts" >> _playerFaction)) then {
+    _playerFaction = "blu_f";
+};
+
+[_display, _playerFaction] call FUNC(gui_gearSelector_loadCategories);
+
+// Set current role to default one
+private _roleCtrl = _display displayCtrl IDC_RSCGEARSELECTOR_ROLE;
+for "_i" from 0 to (lbSize _roleCtrl) do {
+    if ((_roleCtrl lbData _i) isEqualTo _playerRole) exitWith {
+        _roleCtrl lbSetCurSel _i;
+    };
+};

--- a/addons/assigngear/gui/fn_gui_gearSelector_loadCategories.sqf
+++ b/addons/assigngear/gui/fn_gui_gearSelector_loadCategories.sqf
@@ -1,0 +1,42 @@
+
+#include "\x\tmf\addons\assignGear\script_component.hpp"
+
+disableSerialization;
+params ["_display", "_initialFaction"];
+
+private _ctrl = _display displayCtrl IDC_RSCGEARSELECTOR_CATEGORY;
+lbClear _ctrl;
+
+// Add mission category to top
+private _hasMission = false;
+if (count ("true" configClasses (missionConfigFile >> "CfgLoadouts")) > 0) then {
+    _ctrl lbAdd "From Mission File";
+    _hasMission = true;
+};
+
+// Add configFile categories
+private _categories = [];
+{
+    if (isText (_x >> "category")) then {
+        _categories pushBackUnique getText (_x >> "category");
+    } else {
+        _categories pushBackUnique "Other";
+    };
+} forEach ("true" configClasses (configFile >> "CfgLoadouts"));
+
+_categories sort true;
+
+{ _ctrl lbAdd _x} forEach _categories;
+
+// Select the category containing initial faction
+if !(isNil "_initialFaction") then {
+    if (isClass (missionConfigFile >> "CfgLoadouts" >> _initialFaction)) then { _ctrl lbSetCurSel 0} else {
+        private _currCat = ((configFile >> "CfgLoadouts" >> _initialFaction >> "category") call BIS_fnc_GetCfgData) param [0, "Other"];
+        private _currCatIndex = (_categories find _currCat) + ([0,1] select _hasMission);
+        _ctrl lbSetCurSel _currCatIndex;
+
+        [_display, _currCatIndex, _initialFaction] call FUNC(gui_gearSelector_loadFactions);
+    };
+} else {
+    _ctrl lbSetCurSel 0;
+};

--- a/addons/assigngear/gui/fn_gui_gearSelector_loadFactions.sqf
+++ b/addons/assigngear/gui/fn_gui_gearSelector_loadFactions.sqf
@@ -1,0 +1,40 @@
+#include "\x\tmf\addons\assignGear\script_component.hpp"
+
+disableSerialization;
+params ["_display", "_selectedIndex", "_initialFaction"];
+
+private _ctrl = _display displayCtrl IDC_RSCGEARSELECTOR_FACTION;
+lbClear _ctrl;
+private _category = (_display displayCtrl IDC_RSCGEARSELECTOR_CATEGORY) lbText _selectedIndex;
+
+private _loadouts = [];
+private _isMission = false;
+
+switch (_category) do {
+    case "From Mission File": { _isMission = true; _loadouts = "true" configClasses (missionConfigFile >> "CfgLoadouts") };
+    case "Other": { _loadouts = "true" configClasses (configFile >> "CfgLoadouts") select {!isText (_x >> "category")} };
+    default { _loadouts = "true" configClasses (configFile >> "CfgLoadouts") select {getText (_x >> "category") isEqualTo _category} };
+};
+
+// Sort alphabetically and hide duplicate configFile/missionConfigFile loadouts
+MAP(_loadouts, [ARR_2(getText (_x >> "displayName"), toLower configName _x)]);
+if !(_isMission) then {
+    FILTER(_loadouts, !isClass (missionConfigFile >> (_x # 1)));
+};
+_loadouts = [_loadouts] call BIS_fnc_sortBy;
+
+{
+    private _index = _ctrl lbAdd (_x # 0);
+    _ctrl lbSetData [_index, (_x # 1)];
+} forEach _loadouts;
+
+private _selectedIndex2 = 0;
+
+if !(isNil "_initialFaction") then {
+    _selectedIndex2 = _loadouts findIf {_x # 1 isEqualTo _initialFaction};
+    _ctrl lbSetCurSel _selectedIndex2;
+} else {
+    _ctrl lbSetCurSel _selectedIndex2;
+};
+
+[_display, _selectedIndex2] call FUNC(gui_gearSelector_loadRoles);

--- a/addons/assigngear/gui/fn_gui_gearSelector_loadRoles.sqf
+++ b/addons/assigngear/gui/fn_gui_gearSelector_loadRoles.sqf
@@ -1,0 +1,17 @@
+#include "\x\tmf\addons\assignGear\script_component.hpp"
+
+disableSerialization;
+params ["_display", "_selectedIndex"];
+
+private _ctrl = _display displayCtrl IDC_RSCGEARSELECTOR_ROLE;
+lbClear _ctrl;
+private _faction = (_display displayCtrl IDC_RSCGEARSELECTOR_FACTION) lbData _selectedIndex;
+
+private _cfg = if (isClass (missionConfigFile >> "CfgLoadouts" >> _faction)) then [{missionConfigFile}, {configFile}];
+
+{
+    private _index = _ctrl lbAdd getText (_x >> "displayName");
+    _ctrl lbSetData [_index, configName _x];
+} forEach ("true" configClasses (_cfg >> "CfgLoadouts" >> _faction));
+
+_ctrl lbSetCurSel 0;

--- a/addons/assigngear/gui/fn_gui_gearSelector_random.sqf
+++ b/addons/assigngear/gui/fn_gui_gearSelector_random.sqf
@@ -1,0 +1,13 @@
+#include "\x\tmf\addons\assignGear\script_component.hpp"
+
+params ["_display"];
+
+private _loadouts = ("true" configClasses (missionConfigFile >> "CfgLoadouts")) + ("true" configClasses (configFile >> "CfgLoadouts"));
+MAP(_loadouts, toLower configName _x);
+UNIQUE(_loadouts);
+
+[_display, selectRandom _loadouts] call FUNC(gui_gearSelector_loadCategories);
+
+private _roleCtrl = _display displayCtrl IDC_RSCGEARSELECTOR_ROLE;
+
+_roleCtrl lbSetCurSel round random lbSize _roleCtrl;

--- a/addons/assigngear/gui/fn_gui_gearSelector_submit.sqf
+++ b/addons/assigngear/gui/fn_gui_gearSelector_submit.sqf
@@ -1,0 +1,13 @@
+#include "\x\tmf\addons\assignGear\script_component.hpp"
+
+params ["_display"];
+
+private _factionCtrl = _display displayCtrl IDC_RSCGEARSELECTOR_FACTION;
+private _roleCtrl = _display displayCtrl IDC_RSCGEARSELECTOR_ROLE;
+[
+    player,
+    _factionCtrl lbData (lbCurSel _factionCtrl),
+    _roleCtrl lbData (lbCurSel _roleCtrl)
+] call FUNC(assignGear);
+
+_display closeDisplay 1;

--- a/addons/assigngear/gui/gearSelector.hpp
+++ b/addons/assigngear/gui/gearSelector.hpp
@@ -1,67 +1,67 @@
 class GVAR(RscGearSelector) : RscStandardDisplay {
-	idd = IDD_RSCGEARSELECTOR;
-	onLoad = QUOTE(uiNamespace setVariable [ARR_2(QQGVAR(gear_display), _this select 0)]; _this call FUNC(gui_gearSelector_init););
-	onUnload = QUOTE(uiNamespace setVariable [ARR_2(QQGVAR(gear_display), displayNull)];);
+    idd = IDD_RSCGEARSELECTOR;
+    onLoad = QUOTE(uiNamespace setVariable [ARR_2(QQGVAR(gear_display), _this select 0)]; _this call FUNC(gui_gearSelector_init););
+    onUnload = QUOTE(uiNamespace setVariable [ARR_2(QQGVAR(gear_display), displayNull)];);
 
-	class controls {
+    class controls {
         class Title : RscTitle {
-			text = "TMF Loadout Jukebox";
+            text = "TMF Loadout Jukebox";
 
-			x = CENTER_X - 24 * GRID_W;
+            x = CENTER_X - 24 * GRID_W;
             y = CENTER_Y - GRID_H * 15;
             w = 50 * GRID_W;
             h = SIZE_M * GRID_H;
             sizeEx = SIZEEX_PURISTA(SIZEEX_M);
-		};
+        };
         class TitleIcon : RscPicture {
-			text = QPATHTOEF(common,UI\logo_tmf_small_ca.paa);
+            text = QPATHTOEF(common,UI\logo_tmf_small_ca.paa);
 
-			x = CENTER_X - 30 * GRID_W;
+            x = CENTER_X - 30 * GRID_W;
             y = CENTER_Y - GRID_H * 15;
             w = SIZE_M * GRID_H;
             h = SIZE_M * GRID_H;
 
-		};
-		class CategoryLabel : RscText {
-			text = "Category:";
+        };
+        class CategoryLabel : RscText {
+            text = "Category:";
 
-			x = CENTER_X - 30 * GRID_W;
-			y = CENTER_Y - GRID_H * 9;
-			w = 60 * GRID_W;
-			h = SIZE_S * GRID_H;
+            x = CENTER_X - 30 * GRID_W;
+            y = CENTER_Y - GRID_H * 9;
+            w = 60 * GRID_W;
+            h = SIZE_S * GRID_H;
             sizeEx = SIZEEX_PURISTA(SIZEEX_S);
-		};
-		class Category : RscCombo {
-			idc = IDC_RSCGEARSELECTOR_CATEGORY;
+        };
+        class Category : RscCombo {
+            idc = IDC_RSCGEARSELECTOR_CATEGORY;
 
-			x = CENTER_X - 28 * GRID_W;
+            x = CENTER_X - 28 * GRID_W;
             y = CENTER_Y - GRID_H * 5;
-			w = 56 * GRID_W;
-			h = SIZE_S * GRID_H;
+            w = 56 * GRID_W;
+            h = SIZE_S * GRID_H;
             sizeEx = SIZEEX_PURISTA(SIZEEX_S);
 
-			onLBSelChanged = QUOTE( \
+            onLBSelChanged = QUOTE( \
                 params [ARR_2('_ctrl', '_selectedIndex')]; \
                 [ARR_2(ctrlParent _ctrl, _selectedIndex)] call FUNC(gui_gearSelector_loadFactions); \
                 false \
             );
-		};
-		class FactionLabel : RscText {
-			text = "Faction:";
+        };
+        class FactionLabel : RscText {
+            text = "Faction:";
 
-			x = CENTER_X - 30 * GRID_W;
-			y = CENTER_Y - GRID_H * 1;
+            x = CENTER_X - 30 * GRID_W;
+            y = CENTER_Y - GRID_H * 1;
             w = 60 * GRID_W;
-			h = SIZE_S * GRID_H;
+            h = SIZE_S * GRID_H;
             sizeEx = SIZEEX_PURISTA(SIZEEX_S);
-		};
-		class Faction : RscCombo {
-			idc = IDC_RSCGEARSELECTOR_FACTION;
+        };
+        class Faction : RscCombo {
+            idc = IDC_RSCGEARSELECTOR_FACTION;
 
-			x = CENTER_X - 28 * GRID_W;
+            x = CENTER_X - 28 * GRID_W;
             y = CENTER_Y + GRID_H * 3;
-			w = 56 * GRID_W;
-			h = SIZE_S * GRID_H;
+            w = 56 * GRID_W;
+            h = SIZE_S * GRID_H;
             sizeEx = SIZEEX_PURISTA(SIZEEX_S);
 
             onLBSelChanged = QUOTE( \
@@ -69,79 +69,79 @@ class GVAR(RscGearSelector) : RscStandardDisplay {
                 [ARR_2(ctrlParent _ctrl, _selectedIndex)] call FUNC(gui_gearSelector_loadRoles); \
                 false \
             );
-		};
-		class RoleLabel : RscText{
-			text = "Role:";
+        };
+        class RoleLabel : RscText{
+            text = "Role:";
 
-			x = CENTER_X - 30 * GRID_W;
-			y = CENTER_Y + GRID_H * 7;
+            x = CENTER_X - 30 * GRID_W;
+            y = CENTER_Y + GRID_H * 7;
             w = 60 * GRID_W;
-			h = SIZE_S * GRID_H;
+            h = SIZE_S * GRID_H;
             sizeEx = SIZEEX_PURISTA(SIZEEX_S);
-		};
-		class Role : RscCombo{
-			idc = IDC_RSCGEARSELECTOR_ROLE;
+        };
+        class Role : RscCombo{
+            idc = IDC_RSCGEARSELECTOR_ROLE;
 
-			x = CENTER_X - 28 * GRID_W;
+            x = CENTER_X - 28 * GRID_W;
             y = CENTER_Y + GRID_H * 11;
-			w = 56 * GRID_W;
-			h = SIZE_S * GRID_H;
+            w = 56 * GRID_W;
+            h = SIZE_S * GRID_H;
             sizeEx = SIZEEX_PURISTA(SIZEEX_S);
-		};
+        };
 
-		class ButtonCancel : RscButtonMenuCancel {
-			x = CENTER_X - 30 * GRID_W;
-			y = CENTER_Y + GRID_H * 17;
+        class ButtonCancel : RscButtonMenuCancel {
+            x = CENTER_X - 30 * GRID_W;
+            y = CENTER_Y + GRID_H * 17;
             w = (59 / 3) * GRID_W;
-			h = SIZE_M * GRID_H;
+            h = SIZE_M * GRID_H;
             sizeEx = SIZEEX_PURISTA(SIZEEX_S);
-		};
-		class ButtonRandom : RscButtonMenu {
-			text = "Random";
+        };
+        class ButtonRandom : RscButtonMenu {
+            text = "Random";
             idc = IDC_RSCGEARSELECTOR_RANDOM;
 
-			onButtonClick = QUOTE( \
+            onButtonClick = QUOTE( \
                 params ['_ctrl']; \
                 [(ctrlParent _ctrl)] call FUNC(gui_gearSelector_random); \
             );
 
-			x = CENTER_X - ((59 / 3) * GRID_W) / 2;
-			y = CENTER_Y + GRID_H * 17;
-			w = (59 / 3) * GRID_W;
-			h = SIZE_M * GRID_H;
+            x = CENTER_X - ((59 / 3) * GRID_W) / 2;
+            y = CENTER_Y + GRID_H * 17;
+            w = (59 / 3) * GRID_W;
+            h = SIZE_M * GRID_H;
             sizeEx = SIZEEX_PURISTA(SIZEEX_S);
-		};
-		class ButtonOK : RscButtonMenuOK {
+        };
+        class ButtonOK : RscButtonMenuOK {
             idc = IDC_RSCGEARSELECTOR_SUBMIT;
 
-			onButtonClick = QUOTE( \
+            onButtonClick = QUOTE( \
                 params ['_ctrl']; \
                 [(ctrlParent _ctrl)] call FUNC(gui_gearSelector_submit); \
             );
 
-			x = CENTER_X + (GRID_W * 0.5) + ((59 / 3) * GRID_W) / 2;
-			y = CENTER_Y + GRID_H * 17;
-			w = (59 / 3) * GRID_W;
-			h = SIZE_M * GRID_H;
+            x = CENTER_X + (GRID_W * 0.5) + ((59 / 3) * GRID_W) / 2;
+            y = CENTER_Y + GRID_H * 17;
+            w = (59 / 3) * GRID_W;
+            h = SIZE_M * GRID_H;
             sizeEx = SIZEEX_PURISTA(SIZEEX_S);
-		};
-	};
-	class controlsBackground {
+        };
+    };
+    class controlsBackground {
         class TitleBackground : RscBackgroundGUITop {
             x = CENTER_X - 30 * GRID_W;
             y = CENTER_Y - GRID_H * 15;
             w = 60 * GRID_W;
             h = SIZE_M * GRID_H;
 
-			colorBackground[] = {COLOR_ACTIVE_RGBA};
+            colorBackground[] = {COLOR_ACTIVE_RGBA};
 
             backgroundType = 1;
-		};
-		class Background : RscBackgroundGUI {
+        };
+        class Background : RscBackgroundGUI {
             x = CENTER_X - 30 * GRID_W;
             y = CENTER_Y - GRID_H * 9.5;
             w = 60 * GRID_W;
             h = 26 * GRID_H;
-		};
-	};
+        };
+    };
 };

--- a/addons/assigngear/gui/gearSelector.hpp
+++ b/addons/assigngear/gui/gearSelector.hpp
@@ -1,0 +1,147 @@
+class GVAR(RscGearSelector) : RscStandardDisplay {
+	idd = IDD_RSCGEARSELECTOR;
+	onLoad = QUOTE(uiNamespace setVariable [ARR_2(QQGVAR(gear_display), _this select 0)]; _this call FUNC(gui_gearSelector_init););
+	onUnload = QUOTE(uiNamespace setVariable [ARR_2(QQGVAR(gear_display), displayNull)];);
+
+	class controls {
+        class Title : RscTitle {
+			text = "TMF Loadout Jukebox";
+
+			x = CENTER_X - 24 * GRID_W;
+            y = CENTER_Y - GRID_H * 15;
+            w = 50 * GRID_W;
+            h = SIZE_M * GRID_H;
+            sizeEx = SIZEEX_PURISTA(SIZEEX_M);
+		};
+        class TitleIcon : RscPicture {
+			text = QPATHTOEF(common,UI\logo_tmf_small_ca.paa);
+
+			x = CENTER_X - 30 * GRID_W;
+            y = CENTER_Y - GRID_H * 15;
+            w = SIZE_M * GRID_H;
+            h = SIZE_M * GRID_H;
+
+		};
+		class CategoryLabel : RscText {
+			text = "Category:";
+
+			x = CENTER_X - 30 * GRID_W;
+			y = CENTER_Y - GRID_H * 9;
+			w = 60 * GRID_W;
+			h = SIZE_S * GRID_H;
+            sizeEx = SIZEEX_PURISTA(SIZEEX_S);
+		};
+		class Category : RscCombo {
+			idc = IDC_RSCGEARSELECTOR_CATEGORY;
+
+			x = CENTER_X - 28 * GRID_W;
+            y = CENTER_Y - GRID_H * 5;
+			w = 56 * GRID_W;
+			h = SIZE_S * GRID_H;
+            sizeEx = SIZEEX_PURISTA(SIZEEX_S);
+
+			onLBSelChanged = QUOTE( \
+                params [ARR_2('_ctrl', '_selectedIndex')]; \
+                [ARR_2(ctrlParent _ctrl, _selectedIndex)] call FUNC(gui_gearSelector_loadFactions); \
+                false \
+            );
+		};
+		class FactionLabel : RscText {
+			text = "Faction:";
+
+			x = CENTER_X - 30 * GRID_W;
+			y = CENTER_Y - GRID_H * 1;
+            w = 60 * GRID_W;
+			h = SIZE_S * GRID_H;
+            sizeEx = SIZEEX_PURISTA(SIZEEX_S);
+		};
+		class Faction : RscCombo {
+			idc = IDC_RSCGEARSELECTOR_FACTION;
+
+			x = CENTER_X - 28 * GRID_W;
+            y = CENTER_Y + GRID_H * 3;
+			w = 56 * GRID_W;
+			h = SIZE_S * GRID_H;
+            sizeEx = SIZEEX_PURISTA(SIZEEX_S);
+
+            onLBSelChanged = QUOTE( \
+                params [ARR_2('_ctrl', '_selectedIndex')]; \
+                [ARR_2(ctrlParent _ctrl, _selectedIndex)] call FUNC(gui_gearSelector_loadRoles); \
+                false \
+            );
+		};
+		class RoleLabel : RscText{
+			text = "Role:";
+
+			x = CENTER_X - 30 * GRID_W;
+			y = CENTER_Y + GRID_H * 7;
+            w = 60 * GRID_W;
+			h = SIZE_S * GRID_H;
+            sizeEx = SIZEEX_PURISTA(SIZEEX_S);
+		};
+		class Role : RscCombo{
+			idc = IDC_RSCGEARSELECTOR_ROLE;
+
+			x = CENTER_X - 28 * GRID_W;
+            y = CENTER_Y + GRID_H * 11;
+			w = 56 * GRID_W;
+			h = SIZE_S * GRID_H;
+            sizeEx = SIZEEX_PURISTA(SIZEEX_S);
+		};
+
+		class ButtonCancel : RscButtonMenuCancel {
+			x = CENTER_X - 30 * GRID_W;
+			y = CENTER_Y + GRID_H * 17;
+            w = (59 / 3) * GRID_W;
+			h = SIZE_M * GRID_H;
+            sizeEx = SIZEEX_PURISTA(SIZEEX_S);
+		};
+		class ButtonRandom : RscButtonMenu {
+			text = "Random";
+            idc = IDC_RSCGEARSELECTOR_RANDOM;
+
+			onButtonClick = QUOTE( \
+                params ['_ctrl']; \
+                [(ctrlParent _ctrl)] call FUNC(gui_gearSelector_random); \
+            );
+
+			x = CENTER_X - ((59 / 3) * GRID_W) / 2;
+			y = CENTER_Y + GRID_H * 17;
+			w = (59 / 3) * GRID_W;
+			h = SIZE_M * GRID_H;
+            sizeEx = SIZEEX_PURISTA(SIZEEX_S);
+		};
+		class ButtonOK : RscButtonMenuOK {
+            idc = IDC_RSCGEARSELECTOR_SUBMIT;
+
+			onButtonClick = QUOTE( \
+                params ['_ctrl']; \
+                [(ctrlParent _ctrl)] call FUNC(gui_gearSelector_submit); \
+            );
+
+			x = CENTER_X + (GRID_W * 0.5) + ((59 / 3) * GRID_W) / 2;
+			y = CENTER_Y + GRID_H * 17;
+			w = (59 / 3) * GRID_W;
+			h = SIZE_M * GRID_H;
+            sizeEx = SIZEEX_PURISTA(SIZEEX_S);
+		};
+	};
+	class controlsBackground {
+        class TitleBackground : RscBackgroundGUITop {
+            x = CENTER_X - 30 * GRID_W;
+            y = CENTER_Y - GRID_H * 15;
+            w = 60 * GRID_W;
+            h = SIZE_M * GRID_H;
+
+			colorBackground[] = {COLOR_ACTIVE_RGBA};
+
+            backgroundType = 1;
+		};
+		class Background : RscBackgroundGUI {
+            x = CENTER_X - 30 * GRID_W;
+            y = CENTER_Y - GRID_H * 9.5;
+            w = 60 * GRID_W;
+            h = 26 * GRID_H;
+		};
+	};
+};

--- a/addons/assigngear/initCommands.sqf
+++ b/addons/assigngear/initCommands.sqf
@@ -1,0 +1,1 @@
+["loadout",FUNC(chat_loadout), "all"] call CBA_fnc_registerChatCommand;

--- a/addons/assigngear/initSettings.sqf
+++ b/addons/assigngear/initSettings.sqf
@@ -1,0 +1,12 @@
+[
+    QGVAR(loadoutUsage),
+    "LIST",
+    "#loadout available",
+    ["TMF", "Assign Gear"],
+    [
+        [0,         1,                  2,                                  3       ],
+        ["Never",   "During safestart", "During safestart & after respawn", "Always"],
+        0
+    ], // default value
+    1 // isGlobal
+] call CBA_fnc_addSetting;

--- a/addons/assigngear/script_component.hpp
+++ b/addons/assigngear/script_component.hpp
@@ -3,6 +3,14 @@
 #include "\x\tmf\addons\main\script_mod.hpp"
 #include "\x\tmf\addons\main\script_macros.hpp"
 
+/* RscGearSelector*/
+#define IDD_RSCGEARSELECTOR             832400
+#define IDC_RSCGEARSELECTOR_CATEGORY    832401
+#define IDC_RSCGEARSELECTOR_FACTION     832402
+#define IDC_RSCGEARSELECTOR_ROLE        832403
+#define IDC_RSCGEARSELECTOR_SUBMIT      832404
+#define IDC_RSCGEARSELECTOR_RANDOM      832405
+
 /* assignGear specific macros */
 #define GETGEAR(var) [_cfg >> var] call CFUNC(getCfgEntryFromPath)
 #define LIST_2(var1) var1,var1

--- a/addons/common/CfgEventHandlers.hpp
+++ b/addons/common/CfgEventHandlers.hpp
@@ -25,6 +25,14 @@ class Extended_Init_EventHandlers {
     };
 };
 
+class Extended_Respawn_EventHandlers {
+    class CAManBase {
+        class ADDON {
+            respawn = QUOTE((_this select 0) setVariable [ARR_3(QQGVARMAIN(lastRespawn),time,true)]);
+        };
+    };
+};
+
 class Extended_DisplayLoad_EventHandlers {
     class RscDisplayMultiplayerSetup {
         tmf_slotting = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayMultiplayerSetup)'));


### PR DESCRIPTION
This pull request adds a `#loadout` command, with a few different functions.

* `#loadout` - Opens new RscGearSelector, based on the one from presession (credit: @beaar )
* `#loadout <role>` - Assigns a role from the current faction
* `#loadout <player>` - Copies a loadout from another player
* `#loadout <faction> <role>` - Assigns a role from defined faction

The availability of this command can be controlled via CBA settings with 4 options:
* Never Available (Default)
* Available during safestart
* Available during safestart and after respawning
* Always

<details>
<summary>RscGearSelector</summary>

![RscGearSelector](https://user-images.githubusercontent.com/14627848/75094220-906a7d80-5589-11ea-8853-909793592d87.PNG)

I translated the original to use the [A3 Pixel Grid System](https://community.bistudio.com/wiki/Arma_3_Pixel_Grid_System) and macros instead of the original safezone based one, which means that in theory it should scale better across displays, though needs proper testing (Looks good on my 16:9).

Backend functions were rewritten.

</details>