### PR TITLE
HTML briefing

### DIFF
--- a/addons/briefing/CfgFunctions.hpp
+++ b/addons/briefing/CfgFunctions.hpp
@@ -6,6 +6,7 @@ class cfgFunctions {
             class createCreditsPage;
             class generateBriefing;
             class generateLoadoutPage;
+            class parseBriefingHtml;
             class unitPage;
             class vehiclePage;
         };

--- a/addons/briefing/functions/fn_generateBriefing.sqf
+++ b/addons/briefing/functions/fn_generateBriefing.sqf
@@ -55,7 +55,18 @@ private _fnc_fileExists = {
 {
     private _scriptName = (_briefingArray select _x) select 2;
     if ((_scriptName) call _fnc_fileExists) then {
-        call compile preprocessfilelinenumbers _scriptName;
+        if ([".html", _scriptName] call BIS_fnc_inString) then {
+            // html file
+            private _briefingSections = [_scriptName] call FUNC(parseBriefingHtml);
+
+            {
+                _x params ["_header", "_text"];
+                player createDiaryRecord ["Diary",[_header, _text]];
+            } forEach _briefingSections;
+        } else {
+            // Regular SQF
+            call compile preprocessfilelinenumbers _scriptName;
+        };
     } else {
         [_scriptName] spawn {
             params ["_scriptName"];

--- a/addons/briefing/functions/fn_parseBriefingHtml.sqf
+++ b/addons/briefing/functions/fn_parseBriefingHtml.sqf
@@ -54,7 +54,10 @@ private _rtrn = [];
     private _header = _x select [_ind1 + 9, _ind2 - (_ind1 + 9)];
     private _text = _x select [_ind3 + 4, count _x];
 
-    _rtrn pushBack [_header, _text];
+    // Skip commented example section
+    if !(_header isEqualTo "sectionName") then {
+        _rtrn pushBack [_header, _text];
+    };
 } forEach _textArr;
 
 _rtrn

--- a/addons/briefing/functions/fn_parseBriefingHtml.sqf
+++ b/addons/briefing/functions/fn_parseBriefingHtml.sqf
@@ -16,6 +16,21 @@
 params ["_path"];
 
 private _text = loadFile _path;
+
+// Replace HTML header tags
+private _text = [_text, "<h1>", "<font size='18' face='PuristaMedium'>"] call CBA_fnc_replace;
+private _text = [_text, "</h1>", "</font><br/>"] call CBA_fnc_replace;
+private _text = [_text, "<h2>", "<font size='17' face='PuristaMedium'>"] call CBA_fnc_replace;
+private _text = [_text, "</h2>", "</font><br/>"] call CBA_fnc_replace;
+private _text = [_text, "<h3>", "<font size='16'>"] call CBA_fnc_replace;
+private _text = [_text, "</h3>", "</font><br/>"] call CBA_fnc_replace;
+private _text = [_text, "<h4>", "<font size='15'>"] call CBA_fnc_replace;
+private _text = [_text, "</h4>", "</font><br/>"] call CBA_fnc_replace;
+private _text = [_text, "<h5>", "<font size='14'>"] call CBA_fnc_replace;
+private _text = [_text, "</h5>", "</font><br/>"] call CBA_fnc_replace;
+private _text = [_text, "<h6>", "<font size='13'>"] call CBA_fnc_replace;
+private _text = [_text, "</h6>", "</font><br/>"] call CBA_fnc_replace;
+
 private _textArr = [];
 
 while {true} do {

--- a/addons/briefing/functions/fn_parseBriefingHtml.sqf
+++ b/addons/briefing/functions/fn_parseBriefingHtml.sqf
@@ -1,0 +1,45 @@
+/*
+ * Name = TMF_briefing_fnc_parseBriefingHtml
+ * Author = Freddo
+ *
+ * Arguments:
+ * 0: String. Path to file
+ *
+ * Return:
+ * 0: Array. - Format [[_header, _text],[_header, _text]...]
+ *
+ * Description:
+ * Parses a .html file to sections createDiaryRecord can use
+ */
+#include "\x\tmf\addons\briefing\script_component.hpp"
+
+params ["_path"];
+
+private _text = loadFile "_path";
+private _textArr = [];
+
+while {true} do {
+    // Split text into section indicated by "<hr>"
+    private _index = _text find "<hr>";
+    if (_index isEqualTo -1) exitWith {};
+
+    _textArr pushBack (_text select [0, _index]);
+    _text = _text select [_index + 4, count _text];
+};
+
+// Diary records are added in reverse order
+reverse _textArr;
+private _rtrn = [];
+{
+    private _ind1 = _x find "<a name=""";
+    private _ind2 = _x find """>";
+    private _ind3 = _x find "</a>";
+    if (_ind1 == -1 || _ind2 == -1 || _ind3 == -1) exitWith {};
+
+    private _header = _x select [_ind1 + 9, _ind2 - (_ind1 + 9)];
+    private _text = _x select [_ind3 + 4, count _x];
+
+    player pushBack [_header, _text];
+} forEach _textArr;
+
+_rtrn

--- a/addons/briefing/functions/fn_parseBriefingHtml.sqf
+++ b/addons/briefing/functions/fn_parseBriefingHtml.sqf
@@ -15,7 +15,7 @@
 
 params ["_path"];
 
-private _text = loadFile "_path";
+private _text = loadFile _path;
 private _textArr = [];
 
 while {true} do {
@@ -39,7 +39,7 @@ private _rtrn = [];
     private _header = _x select [_ind1 + 9, _ind2 - (_ind1 + 9)];
     private _text = _x select [_ind3 + 4, count _x];
 
-    player pushBack [_header, _text];
+    _rtrn pushBack [_header, _text];
 } forEach _textArr;
 
 _rtrn

--- a/tmf_template.Altis/briefing/briefing_example.html
+++ b/tmf_template.Altis/briefing/briefing_example.html
@@ -1,0 +1,65 @@
+<!-- ===============================================
+    GENERAL BRIEFING NOTES
+     - Uses HTML style syntax. All supported tags can be found here - https://community.bistudio.com/wiki/createDiaryRecord
+	 - In addition to this, headers <h1>text</h1> 1 through 6 are supported
+     - For images use <img image='FILE'></img> (for those familiar with HTML note it is image rather than src).
+	 - Each briefing section is started with <a name="sectionName">sectionName</a> and ended with <hr>
+-->
+
+<!-- ===============================================
+    SITUATION
+     - Outline of what is going on, where we are we and what has happened before the mission has started? This needs to contain any relevant background information.
+     - Draw attention to friendly and enemy forces in the area. The commander will make important decisions based off this information.
+     - Outline present weather conditions, players will typically assume that it is daylight with sunny weather.
+-->
+<h1><a name="Situation">Situation</a></h1>
+*** Insert general information per the above description.***
+<br/><br/>
+<h2>ENEMY FORCES</h2>
+*** Provide information on enemy forces.***
+<br/><br/>
+
+<h2>FRIENDLY FORCES</h2>
+*** Detail friendly forces that are external to the playable force. ***
+<hr>
+
+<!-- ===============================================
+    MISSION
+     - Describe any objectives that the team is expected to complete.
+     - Summarize(!) the overall task. This MUST be short and clear.
+-->
+
+<h1><a name="Mission">Mission</a></h1>
+*** Provide a short summary of the mission objectives here. ***
+<hr>
+<!-- ===============================================
+    EXECUTION
+     - Provide an outline as to what the commander of the player's command might give.
+-->
+
+<h1><a name="Execution">Execution</a></h1>
+<h2>COMMANDER'S INTENT</h2>
+*** Insert very short summary of plan here. ***
+<br/><br/>
+
+<h2>MOVEMENT PLAN</h2>
+*** Insert movement instructions here. ***
+<br/><br/>
+
+<h2>FIRE SUPPORT PLAN</h2>
+*** Provide details on any available fire support. ***
+<br/><br/>
+
+<h6>SPECIAL TASKS</h2>
+*** Insert instructions for specific units here. ***
+<hr>
+<!-- ===============================================
+    ADMINISTRATION
+     - Outline of logistics: available resources (equipment/vehicles) and ideally a summary of their capabilities.
+     - Outline of how to use any mission specific features/scripts.
+     - Seating capacities of each vehicle available for use.
+-->
+
+<h1><a name="Administration">Administration</a></h1>
+*** Insert information on administration and logistics here. ***
+<hr>


### PR DESCRIPTION
This PR adds support for assigning briefings stored in HTML files, not much more to it.

Allows for briefings to be displayed on websites without an SQF parser of sorts.

[Example Briefing.html](https://pastebin.com/MVGUbKPi)