### PR TITLE
Rewrite wavespawner + minor fixes

### DIFF
--- a/addons/ai/functions/fn_spawnWave.sqf
+++ b/addons/ai/functions/fn_spawnWave.sqf
@@ -1,3 +1,16 @@
+/*
+ * Name: TMF_ai_fnc_spawnWave
+ * Author: Head, Snippers
+ *
+ * Arguments:
+ * 0: TMF WaveSpawner logic
+ *
+ * Return:
+ * N/A
+ *
+ * Description:
+ * Handlls spawning units 
+ */
 #include "\x\tmf\addons\AI\script_component.hpp"
 params ["_logic"];
 private _spawnedVehicles = [];

--- a/addons/ai/functions/fn_waveInit.sqf
+++ b/addons/ai/functions/fn_waveInit.sqf
@@ -1,3 +1,18 @@
+/*
+ * Name: TMF_ai_fnc_waveInit
+ * Author: Head, Snippers
+ *
+ * Arguments:
+ * 0: TMF WaveSpawner logic
+ * 1: _units
+ * 2: _activated
+ *
+ * Return:
+ * N/A
+ *
+ * Description:
+ * Handles creation of wavespawner structure
+ */
 if(is3DEN) exitWith {};
 #include "\x\tmf\addons\AI\script_component.hpp"
 params ["_logic","_units","_activated"];

--- a/addons/ai/functions/fn_waveInit.sqf
+++ b/addons/ai/functions/fn_waveInit.sqf
@@ -9,28 +9,58 @@ if(count _headless > 0 && isServer) exitWith {
 
 // check if we have done the setup.
 if(!(_logic getVariable [QGVAR(init),false])) then {
-    private _allgroups = [];
-    
-    {if(side group _x in [blufor,opfor,independent,civilian]) then {_allgroups pushBackUnique group _x};} foreach (synchronizedObjects _logic);
+    private _synchronizedGroups = [];
+    {
+        if(_x isEqualType grpNull && {side _x in [blufor,opfor,independent,civilian]}) then {
+            _synchronizedGroups pushBackUnique _x;
+        };
+        if(_x isEqualType objNull && {side _x in [blufor,opfor,independent,civilian]}) then {
+           if(_x isKindOf 'Man') then {
+               _synchronizedGroups pushBackUnique (group _x);
+           } else {
+               {
+                _synchronizedGroups pushBackUnique (group _x);
+               } foreach crew _x;
+           };
+        };
+    } foreach synchronizedObjects _logic;
+    private _allUnits = [];
+    { _allUnits append (units _x) } forEach _synchronizedGroups;
+    private _vehicles = (_allUnits) apply {objectParent _x} select {!isNull _x};
+    _vehicles = _vehicles arrayIntersect _vehicles;
+    private _groups = [];
 
-    _data = _allgroups apply {
-        _vehicles = [];
-        { if(vehicle _x != _x) then {_vehicles pushBackUnique (vehicle _x)}; } foreach units _x;
-        private _units = (units _x select {vehicle _x == _x}) apply {[typeof _x,getposATL _x,getDir _x,getUnitLoadout _x]};
-        private _vehicles  = _vehicles apply {[typeof _x,getposATL _x,getDir _x,[_x] call BIS_fnc_getVehicleCustomization,crew _x apply {[typeof _x,getpos _x,getUnitLoadout _x]}]};
-        [side _x,_units ,_vehicles,[_x] call CFUNC(serializeWaypoints)];
-    };
+    {
+        private _grp = _x;
+        private _units = (units _grp) apply {
+            private _data = [
+                typeOf _x,
+                getPosATL _x,
+                getDir _x,
+                getUnitLoadout _x,
+                -1,
+                []
+            ];
+            if(!isNull objectParent _x) then {
+                _data set [4, _vehicles find (objectParent _x)];
+                _data set [5, assignedVehicleRole _x]
+            };
+            _data
+        };
+        _groups pushBack [side _x, _units, [_x] call CFUNC(serializeWaypoints)];
+    } forEach _synchronizedGroups;
+    _vehicles = _vehicles apply {[typeof _x,getposATL _x,getDir _x,[_x] call BIS_fnc_getVehicleCustomization]};
 
-    _logic setVariable [QGVAR(waveData), _data];
+    _logic setVariable [QGVAR(waveData), [_groups, _vehicles]];
 
     // Delete the old units/grps
     {
         _units = units _x;
         {
-            if(vehicle _x != _x) then {_units pushBackUnique vehicle _x};
+            if(!isNull objectParent _x) then {_units pushBackUnique vehicle _x};
             deleteVehicle _x;
         } foreach _units;
-    } foreach _allgroups;
+    } foreach _synchronizedGroups;
 
     _logic setVariable [QGVAR(init),true,true];
 };

--- a/addons/spectator/functions/fn_createGroupControl.sqf
+++ b/addons/spectator/functions/fn_createGroupControl.sqf
@@ -22,7 +22,7 @@ else {
     [_control,"\A3\ui_f\data\map\markers\nato\b_unknown.paa",_color] call FUNC(controlSetPicture);
     [_control,groupId _grp] call FUNC(controlSetText);
 };
-[_control,"asd",[],true] call FUNC(controlSetText);
+[_control,"",[],true] call FUNC(controlSetText);
 _grp setVariable [QGVAR(tagControl), [_control]];
 _control setVariable [QGVAR(attached),_grp];
 GVAR(controls) pushBack _control;

--- a/addons/spectator/functions/fn_keyhandler.sqf
+++ b/addons/spectator/functions/fn_keyhandler.sqf
@@ -230,6 +230,7 @@ switch true do {
         GVAR(tracers) = !GVAR(tracers);
         _message = "Tracers have been toggled off";
         if(GVAR(tracers)) then {_message = "Tracers have been toggled on"};
+        systemChat _message;
     };
     case (_key == DIK_K && _type == KEYDOWN): {
         GVAR(bulletTrails) = !GVAR(bulletTrails);


### PR DESCRIPTION
Rewrite of the wave spawner.

- Rewrote most code regarding building the wave data structure into a more sane layout
- Enable the groups inside vehicles to remain independent, an example to task them to get out and perform actions.
- Fix for annoying issue where "asd" would be displayed under a units group marker.
- Added output to the tracers keybind to indicate on and off.

The only problem is that this might cause issues to some missions where the previous wrong behaviour where all units inside a vehicle would be merged into one group will now correctly be separate groups.

I don't think this is very likely to occur frequently.

[video showcase](https://youtu.be/IyuXtf67A9o)
