### PR TITLE
Include parent class faces in facesets

### DIFF
--- a/addons/assigngear/XEH_preStart.sqf
+++ b/addons/assigngear/XEH_preStart.sqf
@@ -25,7 +25,8 @@ uiNamespace setVariable ["tmf_assignGear_validFaces",_faceClasses];
         if (_faceName in _faceClasses) then {
             _weightedArray append [_faceName,_probability];
         };
-    } forEach ("true" configClasses _class);
+    } forEach configProperties [_class, "isClass _x", true];
+    
     if (count _weightedArray > 0) then {
         uiNamespace setVariable ["tmf_assignGear_faceset_"+_name,_weightedArray];
     };


### PR DESCRIPTION
Fixes bug/oversight where (for example) the american and russian facesets don't include the faces from their parent class (caucasian)