### PR TITLE
Add legacy toggle for lobby names

### DIFF
--- a/addons/common/CfgEventHandlers.hpp
+++ b/addons/common/CfgEventHandlers.hpp
@@ -21,9 +21,9 @@ class Extended_Respawn_EventHandlers {
 
 class Extended_DisplayLoad_EventHandlers {
     class RscDisplayMultiplayerSetup {
-        tmf_slotting = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayMultiplayerSetup)'));
+        tmf_slotting = QUOTE(_this call (uiNamespace getVariable QQFUNC(initDisplayMultiplayerSetup)));
     };
     class RscDisplayDebriefing {
-        tmf_override_end_text = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayDebriefing)'));
+        tmf_override_end_text = QUOTE(_this call (uiNamespace getVariable QQFUNC(initDisplayDebriefing)));
     };
 };

--- a/addons/common/functions/fnc_initDisplayMultiplayerSetup.sqf
+++ b/addons/common/functions/fnc_initDisplayMultiplayerSetup.sqf
@@ -4,6 +4,9 @@
 
 params ["_display"];
 
+// CBA Setting
+if !(profileNamespace getVariable [QGVAR(slottingNames), false]) exitWith {};
+
 private _fn_update_group_names_in_lobby = {
     params ["_display"];
     private _slotListControl = _display displayCtrl 109;
@@ -18,7 +21,7 @@ private _fn_update_group_names_in_lobby = {
 
         if (_currentValue isEqualTo -1) then {
             // Value is -1 when it's a groupname.
-            
+
             // Collect descriptions of upcoming roles/terminate if another group appears.
             private _descriptions = [];
             for "_idx" from 0 to (lbSize _slotListControl -1) do {

--- a/addons/common/functions/fnc_testGroupsSlottingScreen.sqf
+++ b/addons/common/functions/fnc_testGroupsSlottingScreen.sqf
@@ -12,6 +12,9 @@
  */
 #include "\x\tmf\addons\autotest\script_component.hpp"
 
+// Disabled by CBA setting
+if !(profileNamespace getVariable [QGVAR(slottingNames), false]) exitWith {};
+
 private _output = [];
 
 // Find groups with playableUnits
@@ -56,7 +59,7 @@ if (count _outputGroups > 0) then {
     {
         _string = _string + ((side _x) call BIS_fnc_sideName) + " - " + groupID _x + ", ";
     } forEach _outputGroups;
-    _output pushBack [1,format ["groups (%1): %2",count _outputGroups,_string]]; 
+    _output pushBack [1,format ["groups (%1): %2",count _outputGroups,_string]];
 };
 
 _output;

--- a/addons/common/initSettings.sqf
+++ b/addons/common/initSettings.sqf
@@ -10,3 +10,15 @@ if (isClass (configFile >> "CfgPatches" >> "ace_safemode")) then {
         true
     ] call CBA_fnc_addSetting;
 };
+[
+    QGVAR(slottingNames),
+    "CHECKBOX",
+    ["Legacy Group Names in Lobby", "Use CBA system instead. Format: Role@Groupname"],
+    ["TMF", "Common"],
+    profileNamespace getVariable [QGVAR(slottingNames),false], // Store from last session
+    0,
+    {
+        profileNamespace setVariable [QGVAR(slottingNames),_this];
+    },
+    true
+] call CBA_fnc_addSetting;


### PR DESCRIPTION
Seeing as CBA has implemented their own system for it, the TMF system is somewhat redundant. https://github.com/CBATeam/CBA_A3/wiki/Name-Groups-in-Lobby

This PR simply adds a toggle setting for it, which is saved in profileNamespace.

Resolves #262