### PR TITLE
Side specific endmission spectator fix

### DIFF
--- a/addons/adminmenu/functions/fnc_endMission_sideSpecificLocal.sqf
+++ b/addons/adminmenu/functions/fnc_endMission_sideSpecificLocal.sqf
@@ -2,7 +2,15 @@
 
 params ["_winners"];
 
-private _isWinner = playerSide in _winners;
+private _playerSide = playerSide;
+
+// Check side before entering spectator
+private _unitData = player getVariable QEGVAR(spectator,unitData);
+if (!isNil "_unitData") then {
+    _playerSide = _unitData # 3;
+};
+
+private _isWinner = _playerSide in _winners;
 
 if (_isWinner) then {
     [QGVAR(victory), true] call EFUNC(common,endMission);

--- a/addons/spectator/config.cpp
+++ b/addons/spectator/config.cpp
@@ -20,7 +20,7 @@ class CfgRespawnTemplates
     class TMF_Spectator
     {
         displayName = "TMF Spectator";
-        onPlayerRespawn  = "tmf_spectator_fnc_init";
+        onPlayerRespawn  = QFUNC(init);
         onPlayerKilled = "";
     };
 };


### PR DESCRIPTION
Makes fnc_sideSpecificLocal check stored spectator data for player side, as playerSide returns sideLogic.