### PR TITLE
New tests for Autotest

### DIFF
--- a/addons/acre2/XEH_PREP.sqf
+++ b/addons/acre2/XEH_PREP.sqf
@@ -2,3 +2,4 @@ PREP(clientInit);
 PREP(createPresets);
 PREP(edenUnitToRadios);
 PREP(unitToPreset);
+PREP(testBabel);

--- a/addons/acre2/XEH_PREP.sqf
+++ b/addons/acre2/XEH_PREP.sqf
@@ -3,3 +3,4 @@ PREP(createPresets);
 PREP(edenUnitToRadios);
 PREP(unitToPreset);
 PREP(testBabel);
+PREP(testNets);

--- a/addons/acre2/autotest.hpp
+++ b/addons/acre2/autotest.hpp
@@ -1,0 +1,5 @@
+class DOUBLES(PREFIX,autotest) {
+    class GVAR(testBabel) {
+        code = QUOTE([] call FUNC(testBabel));
+    };
+};

--- a/addons/acre2/autotest.hpp
+++ b/addons/acre2/autotest.hpp
@@ -2,4 +2,7 @@ class DOUBLES(PREFIX,autotest) {
     class GVAR(testBabel) {
         code = QUOTE([] call FUNC(testBabel));
     };
+    class GVAR(testNets) {
+        code = QUOTE([] call FUNC(testNets));
+    };
 };

--- a/addons/acre2/config.cpp
+++ b/addons/acre2/config.cpp
@@ -17,6 +17,7 @@ class cfgPatches
 
 #include "Cfg3DEN.hpp"
 #include "CfgEventHandlers.hpp"
+#include "autotest.hpp"
 
 /*#include "CfgLoadouts.hpp"*/
 

--- a/addons/acre2/functions/fnc_testBabel.sqf
+++ b/addons/acre2/functions/fnc_testBabel.sqf
@@ -32,13 +32,13 @@ if (getmissionconfigvalue ["TMF_AcreBabelEnabled",false]) then {
         private _index = _babelArray findIf {[_leader, _x # 1] call EFUNC(common,evaluateCondArray)};
 
         if (_index == -1) then {
-            // Check the group condition
+            // Check the group conditions
 
             private _groupCond = _grp getVariable ["TMF_BabelLanguages", []];
             if IS_STRING(_groupCond) then { _groupCond = call compile _groupCond; };
 
             if (_groupCond isEqualTo []) then {
-                // Check the unit conditionz
+                // Check the unit conditions
                 {
                     private _unit = _x;
                     TRACE_1("Autotest checking babel",_unit);
@@ -47,7 +47,7 @@ if (getmissionconfigvalue ["TMF_AcreBabelEnabled",false]) then {
 
                     if (_unitCond isEqualTo []) then {
                         // No languages assigned on each level, post warning.
-                        LOG("No languages assigned for %1",_unit);
+                        WARNING_1("No languages assigned for %1",_unit);
                         _warnings pushBack [0,format ["%1 has no Babel languages assigned", _unit]];
                     };
                 } forEach (units _grp);
@@ -56,7 +56,7 @@ if (getmissionconfigvalue ["TMF_AcreBabelEnabled",false]) then {
     } forEach _playerGroups;
     if (count _warnings == 0) then {
         LOG("Babel Autotest finished");
-        _warnings pushBack [[-1,"Babel checks complete"]];
+        _warnings pushBack [-1,"Babel checks complete"];
     } else {
         WARNING_1("Babel Autotest finished with warnings: %1",_warnings);
     };

--- a/addons/acre2/functions/fnc_testBabel.sqf
+++ b/addons/acre2/functions/fnc_testBabel.sqf
@@ -1,0 +1,65 @@
+#include "\x\tmf\addons\acre2\script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: TMF_acre2_fnc_testBabel
+
+Description:
+    Checks if players have no Babel assigned to them.
+    Used with TMF Autotest.
+
+Returns:
+    Warning array [Array of Warnings]
+
+Author:
+    Freddo
+---------------------------------------------------------------------------- */
+
+private _warnings = [];
+
+if (getmissionconfigvalue ["TMF_AcreBabelEnabled",false]) then {
+    LOG("Running Autotest on Babel");
+    private _babelArray = getMissionConfigValue ["TMF_AcreBabelSettings", []];
+    if IS_STRING(_babelArray) then {_babelArray = call compile _babelArray};
+
+    private _playerGroups = (playableUnits + [player]) apply {group _x};
+    UNIQUE(_playerGroups);
+
+    {
+        // Check side/faction conditions
+
+        private _grp = _x;
+        TRACE_1("Autotest checking babel",_grp);
+        private _leader = leader _grp;
+        private _index = _babelArray findIf {[_leader, _x # 1] call EFUNC(common,evaluateCondArray)};
+
+        if (_index == -1) then {
+            // Check the group condition
+
+            private _groupCond = _grp getVariable ["TMF_BabelLanguages", []];
+            if IS_STRING(_groupCond) then { _groupCond = call compile _groupCond; };
+
+            if (_groupCond isEqualTo []) then {
+                // Check the unit conditionz
+                {
+                    private _unit = _x;
+                    TRACE_1("Autotest checking babel",_unit);
+                    private _unitCond = _unit getVariable ["TMF_BabelLanguages", []];
+                    if IS_STRING(_unitCond) then { _unitCond = call compile _unitCond; };
+
+                    if (_unitCond isEqualTo []) then {
+                        // No languages assigned on each level, post warning.
+                        LOG("No languages assigned for %1",_unit);
+                        _warnings pushBack [0,format ["%1 has no Babel languages assigned", _unit]];
+                    };
+                } forEach (units _grp);
+            };
+        };
+    } forEach _playerGroups;
+    if (count _warnings == 0) then {
+        LOG("Babel Autotest finished");
+        _warnings pushBack [[-1,"Babel checks complete"]];
+    } else {
+        WARNING_1("Babel Autotest finished with warnings: %1",_warnings);
+    };
+};
+
+_warnings

--- a/addons/acre2/functions/fnc_testNets.sqf
+++ b/addons/acre2/functions/fnc_testNets.sqf
@@ -1,0 +1,65 @@
+#include "\x\tmf\addons\acre2\script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: TMF_acre2_fnc_testNets
+
+Description:
+    Checks if players have no radio nets assigned to them.
+    Used with TMF Autotest.
+
+Returns:
+    Warning array [Array of Warnings]
+
+Author:
+    Freddo
+---------------------------------------------------------------------------- */
+
+private _warnings = [];
+
+if (getmissionconfigvalue ["TMF_AcreNetworkEnabled",false]) then {
+    LOG("Running Autotest on Radio Networks");
+    private _networksArray = getMissionConfigValue ['TMF_AcreSettings', []];
+    if IS_STRING(_networksArray) then {_networksArray = call compile _networksArray};
+
+    private _playerGroups = (playableUnits + [player]) apply {group _x};
+    UNIQUE(_playerGroups);
+
+    {
+        // Check side/faction conditions
+
+        private _grp = _x;
+        TRACE_1("Autotest checking Radio Networks",_grp);
+        private _leader = leader _grp;
+        private _index = _networksArray findIf {[_leader, _x # 0] call EFUNC(common,evaluateCondArray)};
+
+        if (_index == -1) then {
+            // Check the group condition
+
+            private _groupCond = _grp getVariable ["TMF_Network", -1];
+            if IS_STRING(_groupCond) then { _groupCond = call compile _groupCond; };
+
+            if (_groupCond isEqualTo -1 || _groupCond > (count (_networksArray # 0)) - 1) then {
+                // Check the unit conditions
+                {
+                    private _unit = _x;
+                    TRACE_1("Autotest checking Radio Networks",_unit);
+                    private _unitCond = _unit getVariable ["TMF_Network", -1];
+                    if IS_STRING(_unitCond) then { _unitCond = call compile _unitCond; };
+
+                    if (_unitCond isEqualTo -1 || _unitCond > (count (_networksArray # 0)) - 1) then {
+                        // No nets assigned on each level, post warning.
+                        WARNING_1("No Radio Nets assigned for %1",_unit);
+                        _warnings pushBack [0,format ["%1 has no Radio Networks assigned", _unit]];
+                    };
+                } forEach (units _grp);
+            };
+        };
+    } forEach _playerGroups;
+    if (count _warnings == 0) then {
+        LOG("Radio Net Autotest finished");
+        _warnings pushBack [-1,"ACRE2 Radio Network checks complete"];
+    } else {
+        WARNING_1("Radio Networks Autotest finished with warnings: %1",_warnings);
+    };
+};
+
+_warnings

--- a/addons/assigngear/XEH_PREP.sqf
+++ b/addons/assigngear/XEH_PREP.sqf
@@ -22,6 +22,7 @@ PREP(setInsignia);
 PREP(setUnitTrait);
 PREP(onEdenMessageRecieved);
 PREP(onEdenMissionChange);
+PREP(testGear);
 
 PREP(gui_gearSelector_init);
 PREP(gui_gearSelector_loadFactions);

--- a/addons/assigngear/autotest.hpp
+++ b/addons/assigngear/autotest.hpp
@@ -1,0 +1,6 @@
+class DOUBLES(PREFIX,autotest) {
+    class GVAR(testGear) {
+        code = QUOTE([] call FUNC(testGear));
+        maxWeight = 35; //kg
+    };
+};

--- a/addons/assigngear/config.cpp
+++ b/addons/assigngear/config.cpp
@@ -41,6 +41,7 @@ class RscDisplayArsenal
    };
 };
 #include "CfgEventHandlers.hpp"
+#include "autotest.hpp"
 #include "CfgLoadouts.hpp"
 #include "Cfg3DEN.hpp"
 #include "CfgFaceSets.hpp"

--- a/addons/assigngear/functions/fnc_testGear.sqf
+++ b/addons/assigngear/functions/fnc_testGear.sqf
@@ -1,12 +1,13 @@
 //fn_testGear
 //
-#include "\x\tmf\addons\autotest\script_component.hpp"
+#include "\x\tmf\addons\assigngear\script_component.hpp"
 
 
 private _cfgWeapons = configFile >> "CfgWeapons";
 private _cfgVehicles = configFile >> "CfgVehicles";
 private _cfgGlasses = configFile >> "CfgGlasses";
 private _cfgMagazines = configFile >> "CfgMagazines";
+private _warnWeight = getNumber (_test >> "warnWeight");
 
 
 private _output = [];
@@ -246,10 +247,10 @@ private _loadoutFreespace = [];
         if (_index != -1) then {
             _freespace = [_faction,_role] call _fncTestUnit;
             _loadoutFreespace pushBack _freespace;
-            _unit call EFUNC(assigngear,assignGear);
+            _unit call FUNC(assignGear);
             private _weight = (loadAbs _unit) * 0.1;
             _weight = (round (_weight * (1/2.2046) * 100)) / 100; // ACE calculation
-            if (_weight >= 35) then {
+            if (_weight >= _warnWeight) then {
                 _output pushBack [1,format["Heavy role %1kg (for: %2 - %3)",_weight,_faction,_role]];
             };
         } else {
@@ -289,10 +290,6 @@ private _loadoutFreespace = [];
         } forEach _radios;
     };
 } forEach allUnits;
-
-
-
-
 
 _output pushBack [-1,"AssignGear checks complete."];
 

--- a/addons/autotest/XEH_PREP.sqf
+++ b/addons/autotest/XEH_PREP.sqf
@@ -4,3 +4,4 @@ PREP(testEndings);
 PREP(testInit);
 PREP(testGroups);
 PREP(testAI);
+PREP(testHCs);

--- a/addons/autotest/XEH_PREP.sqf
+++ b/addons/autotest/XEH_PREP.sqf
@@ -1,4 +1,5 @@
 PREP(autotest);
+PREP(testDLC);
 PREP(testEndings);
 PREP(testGear);
 PREP(testInit);

--- a/addons/autotest/XEH_PREP.sqf
+++ b/addons/autotest/XEH_PREP.sqf
@@ -1,5 +1,6 @@
 PREP(autotest);
 PREP(testDLC);
 PREP(testEndings);
-PREP(testGear);
 PREP(testInit);
+PREP(testGroups);
+PREP(testAI);

--- a/addons/autotest/XEH_preStart.sqf
+++ b/addons/autotest/XEH_preStart.sqf
@@ -1,3 +1,10 @@
 #include "script_component.hpp"
 
 #include "XEH_PREP.sqf"
+
+// Store DLC hash
+private _dlcClasses = "isNumber (_x >> 'appID')" configClasses (configFile >> "CfgMods");
+
+private _dlcHash = _dlcClasses apply {[getNumber (_x >> "appID"), getText (_x >> "nameShort")]};
+
+uiNamespace setVariable [QGVAR(dlcHash), [_dlcHash, "Unknown"] call CBA_fnc_hashCreate];

--- a/addons/autotest/autotest.hpp
+++ b/addons/autotest/autotest.hpp
@@ -1,0 +1,35 @@
+class ADDON {
+    /* class exampleTest {
+      code = "";
+    };
+
+    Code should return an array of warnings (array consisting of a number and a string)
+    [
+    [-1,"test here"]
+    ]
+
+    1 = Error
+    -1 = Success
+    0 = Warning
+
+    */
+    class GVAR(testInit) {
+        code = QUOTE([] call FUNC(testInit));
+    };
+    class GVAR(testEndings) {
+        code = QUOTE([] call FUNC(testEndings));
+    };
+    class GVAR(testGroups) {
+        code = QUOTE([] call FUNC(testGroups));
+        warningAmount = 200;
+    };
+    class GVAR(testAI) {
+        code = QUOTE([] call FUNC(testAI));
+        warningAmount = 160;
+        errorAmount = 200;
+    };
+    class GVAR(checkDLC) {
+        code = QUOTE([] call FUNC(testDLC));
+        ignoredDLC[] = {/*798390*/};
+    };
+};

--- a/addons/autotest/autotest.hpp
+++ b/addons/autotest/autotest.hpp
@@ -28,8 +28,12 @@ class ADDON {
         warningAmount = 160;
         errorAmount = 200;
     };
-    class GVAR(checkDLC) {
+    class GVAR(testDLC) {
         code = QUOTE([] call FUNC(testDLC));
         ignoredDLC[] = {/*798390*/};
+    };
+    class GVAR(testHCs) {
+        code = QUOTE([] call FUNC(testHCs));
+        expectedHCs = 0;
     };
 };

--- a/addons/autotest/config.cpp
+++ b/addons/autotest/config.cpp
@@ -18,24 +18,4 @@ class cfgPatches
 #include "CfgEventHandlers.hpp"
 #include "Cfg3DEN.hpp"
 #include "display3DEN.hpp"
-
-class ADDON {
-    /* class exampleTest {
-      code = "";
-    };
-
-    Code should return an array of warnings (array consisting of a number and a string)
-    [
-    [-1,"test here"]
-    ]
-
-    1 = Error
-    -1 = Success
-    0 = Warning
-
-    */
-
-    class GVAR(checkDLC) {
-        code = QUOTE([] call FUNC(testDLC));
-    };
-};
+#include "autotest.hpp"

--- a/addons/autotest/config.cpp
+++ b/addons/autotest/config.cpp
@@ -20,18 +20,22 @@ class cfgPatches
 #include "display3DEN.hpp"
 
 class ADDON {
-  /* class exampleTest {
+    /* class exampleTest {
       code = "";
-  };
+    };
 
-  Code should return an array of warnings (array consisting of a number and a string)
-  [
+    Code should return an array of warnings (array consisting of a number and a string)
+    [
     [-1,"test here"]
-  ]
+    ]
 
-  1 = Error
-  -1 = Success
-  0 = Warning
+    1 = Error
+    -1 = Success
+    0 = Warning
 
-  */
+    */
+
+    class GVAR(checkDLC) {
+        code = QUOTE([] call FUNC(testDLC));
+    };
 };

--- a/addons/autotest/functions/fnc_autotest.sqf
+++ b/addons/autotest/functions/fnc_autotest.sqf
@@ -1,58 +1,23 @@
+#define DEBUG_MODE_FULL
 #include "\x\tmf\addons\autotest\script_component.hpp"
 
 private _ctrlListbox = (_this controlsGroupCtrl 101);
 _ctrlListbox lnbSetColumnsPos [0,0.05];
 
-//private _lnbAdd = _ctrlListbox lnbAddRow ["","test"];
-
-//_ctrlListbox lnbSetPicture [[_lnbAdd,0],"\x\tmf\addons\briefing\UI\check_small_ca.paa"];
-
-// Do the tests.
 private _output = [];
-_output append ([] call FUNC(testGear));
-_output append ([] call FUNC(testInit));
-_output append ([] call FUNC(testEndings));
-
-
-//Group count check.
-{
-    private _side = _x;
-    private _groupCount = {(side _x isEqualTo _side)} count allGroups;
-    if (_groupCount > 200) then {
-        _output pushBack [1,format["Side %1 has %2 groups. Note Arma has a 288 group limit per side.",_side,_groupCount]];
-    }
-} forEach [west,east,civilian,resistance];
-
-// AI Numbers check
-
-private _array = playableUnits + [player];
-private _aiCount = {!(_x in _array)} count allUnits;
-
-if (_aiCount > 160) then {
-    if (_aiCount > 200) then {
-        _output pushBack [0,format["You have placed %1 AI. You may wish to consider the performance impact.",_aiCount]];
-    } else {
-        _output pushBack [1,format["You have placed %1 AI. You may wish to consider the performance impact.",_aiCount]];
-    };
-};
-
-// TMF Spectator configured.
-
-if (!((getMissionConfigValue ["respawn",0] == 1) and ("TMF_Spectator" in (getMissionConfigValue ["respawnTemplates",[]])))) then {
-    _output pushBack [0,"TMF Spectator is not setup correctly. See wiki for instructions."];
-};
 
 // Process the Config based auto-tests.
-
 {
     private _test = _x;
+    LOG_1("Running test: %1",configName _x);
     private _code = getText (_test >> "code");
 
     private _outputTest = call compile _code;
     if (_outputTest isEqualType []) then {
         _output append _outputTest;
-    }
-} forEach (configProperties [configFile >> "TMF_autoTest","isClass _x"]);
+        TRACE_2("Appending to output",_output,_outputTest);
+    };
+} forEach ("true" configClasses (configFile >> 'ADDON'));
 
 
 // Display them on the auto-test UI page in Eden.
@@ -67,7 +32,7 @@ if (!((getMissionConfigValue ["respawn",0] == 1) and ("TMF_Spectator" in (getMis
         _ctrlListbox lnbSetPicture [[_lnbAdd,0],QPATHTOEF(briefing,UI\check_small_ca.paa)];
     };
     if (_type == 1) then { //Warning
-        _ctrlListbox lnbSetPicture [[_lnbAdd,0],QPATHTOEF(briefing,UI\warning.paa)];
+        _ctrlListbox lnbSetPicture [[_lnbAdd,0],QPATHTOEF(autotest,UI\warning.paa)];
     };
 
 } forEach _output;

--- a/addons/autotest/functions/fnc_testAI.sqf
+++ b/addons/autotest/functions/fnc_testAI.sqf
@@ -1,0 +1,19 @@
+#include "\x\tmf\addons\autotest\script_component.hpp"
+
+// AI Numbers check
+private _output = [];
+private _warningAmount = getNumber (_test >> "warningAmount");
+private _errorAmount = getNumber (_test >> "errorAmount");
+
+private _array = playableUnits + [player];
+private _aiCount = {!(_x in _array)} count allUnits;
+
+if (_aiCount > _warningAmount) then {
+    if (_aiCount > _errorAmount) then {
+        _output pushBack [0,format["You have placed %1 AI. You may wish to consider the performance impact.",_aiCount]];
+    } else {
+        _output pushBack [1,format["You have placed %1 AI. You may wish to consider the performance impact.",_aiCount]];
+    };
+};
+
+_output

--- a/addons/autotest/functions/fnc_testDLC.sqf
+++ b/addons/autotest/functions/fnc_testDLC.sqf
@@ -14,6 +14,7 @@ Author:
 
 LOG("Running DLC tests");
 private _warnings = [];
+private _ignoredDLC = getArray (_test >> "ignoredDLC");
 
 private _allUnits = (playableUnits + [player]);
 private _unitsDLCInfo = _allUnits apply {[_x,getPersonUsedDLCs _x]};
@@ -26,12 +27,13 @@ private _missionSummary = "Multiplayer" get3DENMissionAttribute "IntelOverviewTe
     TRACE_2("Checking unit for DLC",_unit,_dlcArr);
 
     // Get DLC short names from preStart hash
+    _dlcArr = _dlcArr - _ignoredDLC;
     _dlcArr = _dlcArr apply { [_dlcHash, _x] call CBA_fnc_hashGet };
 
     private _roleDescription = (_unit get3DENAttribute "description") select 0;
     _dlcArr = _dlcArr select {
         !([_x, _roleDescription] call BIS_fnc_inString) && // DLC usage mentioned in role description
-        !([_x, _missionSummary] call BIS_fnc_inString)  && // DLC usage mentioned in mission summary
+        !([_x, _missionSummary] call BIS_fnc_inString)     // DLC usage mentioned in mission summary
     };
 
     if !(_dlcArr isEqualTo []) then {
@@ -55,14 +57,16 @@ private _problemVehsDLC = [];
     TRACE_2("Checking vehicle for DLC",_veh,_dlc);
 
     // Get DLC short names from preStart hash
-    _dlc = [_dlcHash, _dlc] call CBA_fnc_hashGet;
+    if !(_dlc in _ignoredDLC) then {
+        _dlc = [_dlcHash, _dlc] call CBA_fnc_hashGet;
 
-    private _index = _searchTexts findIf {[_dlc,_x] call BIS_fnc_inString};
+        private _index = _searchTexts findIf {[_dlc,_x] call BIS_fnc_inString};
 
-    if (_index == -1) then {
-        TRACE_2("Vehicle found using unlisted DLC",_veh,_dlc);
-        _problemVehs = _problemVehs + 1;
-        _problemVehsDLC pushBackUnique _dlc;
+        if (_index == -1) then {
+            TRACE_2("Vehicle found using unlisted DLC",_veh,_dlc);
+            _problemVehs = _problemVehs + 1;
+            _problemVehsDLC pushBackUnique _dlc;
+        };
     };
 } forEach (_vehicleDLCInfo select {!isNil {(_x # 1)}});
 

--- a/addons/autotest/functions/fnc_testDLC.sqf
+++ b/addons/autotest/functions/fnc_testDLC.sqf
@@ -17,7 +17,10 @@ private _warnings = [];
 private _ignoredDLC = getArray (_test >> "ignoredDLC");
 
 private _allUnits = (playableUnits + [player]);
-private _unitsDLCInfo = _allUnits apply {[_x,getPersonUsedDLCs _x]};
+private _unitsDLCInfo = _allUnits apply {
+    _x setUnitLoadout getUnitLoadout _x; // Needed to properly register DLC usage
+    [_x,getPersonUsedDLCs _x]
+};
 private _dlcHash = uiNamespace getVariable QGVAR(dlcHash);
 private _missionSummary = "Multiplayer" get3DENMissionAttribute "IntelOverviewText";
 

--- a/addons/autotest/functions/fnc_testDLC.sqf
+++ b/addons/autotest/functions/fnc_testDLC.sqf
@@ -1,0 +1,85 @@
+#include "\x\tmf\addons\autotest\script_component.hpp"
+/* ----------------------------------------------------------------------------
+Internal Function: TMF_autotest_fnc_testDLC
+
+Description:
+    Checks units/vehicles DLC usage
+
+Returns:
+    Warning array [Array of Warnings]
+
+Author:
+    Freddo
+---------------------------------------------------------------------------- */
+
+LOG("Running DLC tests");
+private _warnings = [];
+
+private _allUnits = (playableUnits + [player]);
+private _unitsDLCInfo = _allUnits apply {[_x,getPersonUsedDLCs _x]};
+private _dlcHash = uiNamespace getVariable QGVAR(dlcHash);
+private _missionSummary = "Multiplayer" get3DENMissionAttribute "IntelOverviewText";
+
+// Check units for DLC
+{
+    _x params ["_unit","_dlcArr"];
+    TRACE_2("Checking unit for DLC",_unit,_dlcArr);
+
+    // Get DLC short names from preStart hash
+    _dlcArr = _dlcArr apply { [_dlcHash, _x] call CBA_fnc_hashGet };
+
+    private _roleDescription = (_unit get3DENAttribute "description") select 0;
+    _dlcArr = _dlcArr select {
+        !([_x, _roleDescription] call BIS_fnc_inString) && // DLC usage mentioned in role description
+        !([_x, _missionSummary] call BIS_fnc_inString)  && // DLC usage mentioned in mission summary
+    };
+
+    if !(_dlcArr isEqualTo []) then {
+        TRACE_2("Unit has unlisted DLC",_unit,_dlcArr);
+        _warnings pushBack [
+            0,
+            format ["%1 needs notice for following DLC: %2", _unit, _dlcArr]
+        ];
+    };
+} forEach (_unitsDLCInfo select {!(_x # 1 isEqualTo [])});
+
+private _vehicleDLCInfo = vehicles apply {[_x,getObjectDLC _x]};
+private _roleDescriptions = _allUnits apply {(_x get3DENAttribute "description") select 0};
+private _searchTexts = [_missionSummary] + _roleDescriptions;
+private _problemVehs = 0;
+private _problemVehsDLC = [];
+
+// Check placed vehicles for DLC
+{
+    _x params ["_veh", "_dlc"];
+    TRACE_2("Checking vehicle for DLC",_veh,_dlc);
+
+    // Get DLC short names from preStart hash
+    _dlc = [_dlcHash, _dlc] call CBA_fnc_hashGet;
+
+    private _index = _searchTexts findIf {[_dlc,_x] call BIS_fnc_inString};
+
+    if (_index == -1) then {
+        TRACE_2("Vehicle found using unlisted DLC",_veh,_dlc);
+        _problemVehs = _problemVehs + 1;
+        _problemVehsDLC pushBackUnique _dlc;
+    };
+} forEach (_vehicleDLCInfo select {!isNil {(_x # 1)}});
+
+if (_problemVehs > 0) then {
+    if (_problemVehs > 1) then {
+        _warnings pushBack [
+            1,
+            format ["There are %1 vehicles present from unmentioned DLC: %2", _problemVehs, _problemVehsDLC]
+        ];
+    } else {
+        _warnings pushBack [
+            1,
+            format ["There is %1 vehicle present from unmentioned DLC: %2", _problemVehs, _problemVehsDLC]
+        ];
+    };
+};
+
+LOG_1("Finished DLC Tests: %1", _warnings);
+
+_warnings

--- a/addons/autotest/functions/fnc_testEndings.sqf
+++ b/addons/autotest/functions/fnc_testEndings.sqf
@@ -3,18 +3,8 @@
 private _output = [];
 
 // Check if endings are set.
-
-private _i = 0;
-private _config = missionConfigFile >> "CfgDebriefing";
-private _count = count _config;
-
-if (_count != 3) exitWith {}; //default template
-
-while {_i < _count} do {
-    if (configName (_config select _i) == "CustomEnding1") exitWith {
-        _output pushBack [1,"CustomEnding1 is still present. Mission endings are probably not configured."];  
-    };
-    _i = _i + 1;
+if (isClass (missionConfigFile >> "CfgDebriefing" >> "CustomEnding1")) then {
+    _output pushBack [1,"CustomEnding1 is still present. Mission endings are probably not configured."];
 };
 
-_output;
+_output

--- a/addons/autotest/functions/fnc_testGroups.sqf
+++ b/addons/autotest/functions/fnc_testGroups.sqf
@@ -1,0 +1,13 @@
+#include "\x\tmf\addons\autotest\script_component.hpp"
+
+private _output = [];
+//Group count check.
+{
+    private _side = _x;
+    private _groupCount = {(side _x isEqualTo _side)} count allGroups;
+    if (_groupCount > 200) then {
+        _output pushBack [1,format["Side %1 has %2 groups. Note Arma has a 288 group limit per side.",_side,_groupCount]];
+    }
+} forEach [west,east,civilian,resistance];
+
+_output

--- a/addons/autotest/functions/fnc_testHCs.sqf
+++ b/addons/autotest/functions/fnc_testHCs.sqf
@@ -1,0 +1,32 @@
+#include "\x\tmf\addons\autotest\script_component.hpp"
+/* ----------------------------------------------------------------------------
+Internal Function: TMF_autotest_fnc_testHCs
+
+Description:
+    Checks number of HCs and if they're set up correctly
+
+Returns:
+    Warning array [Array of Warnings]
+
+Author:
+    Freddo
+---------------------------------------------------------------------------- */
+
+private _warnings = [];
+private _targetHCs = getNumber (_test >> "expectedHCs");
+
+private _HCs = (all3DENEntities # 3) select {_x isKindOf "HeadlessClient_F"};
+
+// Check presence
+if (count _HCs < _targetHCs) then {
+    _warnings pushBack [1,format ["Less than %1 Headless Clients present",_targetHCs]];
+};
+
+// Check if setup correctly
+{
+    if !(_x get3DENAttribute "ControlMP" isEqualTo [true]) then {
+        _warnings pushBack [0,format ["Headless Client %1 is not marked as playable.",_x]];
+    };
+} forEach _HCs;
+
+_warnings

--- a/addons/common/functions/fnc_evaluateCondArray.sqf
+++ b/addons/common/functions/fnc_evaluateCondArray.sqf
@@ -9,14 +9,14 @@
  * Boolean
  *
  * Description:
- * Use this function to see check if a unit matches any conditions in the arrays. Apropriate conditions are sides (Side type variables or scalars), factions (all strings are assumed factions), 
+ * Use this function to see check if a unit matches any conditions in the arrays. Apropriate conditions are sides (Side type variables or scalars), factions (all strings are assumed factions),
  */
 
 params ["_unit", "_condArray"];
 private _return = false;
 {
-    if ((_x isEqualType "") and {_x == (faction (leader _unitGroup))}) exitWith { _return = true; };
-    if ((_x isEqualType 0) && {(_x call tmf_common_fnc_numToSide) == side _unit}) exitWith { _return = true; };
+    if ((_x isEqualType "") and {_x == (faction (leader _unit))}) exitWith { _return = true; };
+    if ((_x isEqualType 0) && {(_x call EFUNC(common,numToSide)) == side _unit}) exitWith { _return = true; };
     if ((_x isEqualType east) && {_x == side _unit}) exitWith { _return = true;};
 } forEach _condArray;
 

--- a/addons/common/functions/fnc_evaluateCondArray.sqf
+++ b/addons/common/functions/fnc_evaluateCondArray.sqf
@@ -1,3 +1,4 @@
+#include "\x\tmf\addons\common\script_component.hpp"
 /*
  * Name: TMF_common_fnc_evaluateCondArray
  * Author: Snippers

--- a/addons/spectator/XEH_PREP.sqf
+++ b/addons/spectator/XEH_PREP.sqf
@@ -32,3 +32,4 @@ PREP(controlSetPicture);
 PREP(createUnitControl);
 PREP(createVehicleControl);
 PREP(updateKillList);
+PREP(testSpectator);

--- a/addons/spectator/autotest.hpp
+++ b/addons/spectator/autotest.hpp
@@ -1,0 +1,5 @@
+class DOUBLES(PREFIX,autotest) {
+    class GVAR(testSpectator) {
+        code = QUOTE([] call FUNC(testSpectator));
+    };
+};

--- a/addons/spectator/config.cpp
+++ b/addons/spectator/config.cpp
@@ -24,6 +24,7 @@ class CfgRespawnTemplates
         onPlayerKilled = "";
     };
 };
+#include "autotest.hpp"
 #include "CfgEventHandlers.hpp"
 #include "Cfg3DEN.hpp"
 #include "display3DEN.hpp"

--- a/addons/spectator/functions/fnc_testSpectator.sqf
+++ b/addons/spectator/functions/fnc_testSpectator.sqf
@@ -1,0 +1,9 @@
+#include "\x\tmf\addons\spectator\script_component.hpp"
+// TMF Spectator configured.
+private _output = [];
+
+if (!((getMissionConfigValue ["respawn",0] == 1) and ("TMF_Spectator" in (getMissionConfigValue ["respawnTemplates",[]])))) then {
+    _output pushBack [0,"TMF Spectator is not setup correctly. See wiki for instructions."];
+};
+
+_output


### PR DESCRIPTION
##### This pull request adds the following tests

* Test for unmentioned DLC usage (vehicles and player units)
* Test for number of HCs, and if they're correctly set up.
* Test babel
* Test radio network assignment
---
Additionally all autotests were moved from `fnc_autotest` to config, and to separate components.  
Warning amounts are now also pulled from autotest config.