### PR TITLE
Wavespawner improvements

### DIFF
--- a/addons/ai/CfgModules.hpp
+++ b/addons/ai/CfgModules.hpp
@@ -4,15 +4,15 @@ class CfgVehicles
     class Module_F: Logic
     {
         class AttributesBase
-		{
-			class Default;
-			class Edit;
-			class Combo;
-			class Checkbox;
-			class CheckboxNumber;
-			class ModuleDescription;
-			class Units;
-		};
+        {
+            class Default;
+            class Edit;
+            class Combo;
+            class Checkbox;
+            class CheckboxNumber;
+            class ModuleDescription;
+            class Units;
+        };
         class ArgumentsBaseUnits
         {
             class Units;

--- a/addons/ai/CfgModules.hpp
+++ b/addons/ai/CfgModules.hpp
@@ -3,6 +3,16 @@ class CfgVehicles
     class Logic;
     class Module_F: Logic
     {
+        class AttributesBase
+		{
+			class Default;
+			class Edit;
+			class Combo;
+			class Checkbox;
+			class CheckboxNumber;
+			class ModuleDescription;
+			class Units;
+		};
         class ArgumentsBaseUnits
         {
             class Units;
@@ -11,6 +21,7 @@ class CfgVehicles
         {
             class AnyBrain;
         };
+        class EventHandlers;
     };
     #include "modules\area.hpp"
     #include "modules\waveSpawner.hpp"

--- a/addons/ai/functions/fnc_addWaveHandler.sqf
+++ b/addons/ai/functions/fnc_addWaveHandler.sqf
@@ -1,3 +1,4 @@
+#include "\x\tmf\addons\AI\script_component.hpp"
 /*
  * Name: TMF_ai_fnc_addWaveHandler
  * Author: Head
@@ -5,19 +6,23 @@
  * Arguments:
  * 0: The wave spawner logic <OBJECT>
  * 1: Code to execute <CODE>
+ * 2: Global effect <BOOL>
  *
  * Return:
- * None
+ * Nothing
  *
  * Description:
  * Adds an eventhandler to a wave spawner that execute everytime a wave is spawned.
- * Local execution only.
  */
 
-params ["_logic","_code"];
+params ["_logic","_code", ["_isGlobal",false]];
+
+if (_isGlobal && !isRemoteExecuted) exitWith {
+    [_logic,_code,false] remoteExecCall [QFUNC(addWaveHandler),0,true];
+};
 
 private _handlers = _logic getVariable ["Handlers", []];
 private _index = _handlers pushBack _code;
 _logic setVariable ["Handlers", _handlers, false];
 
-_index
+//_index

--- a/addons/ai/functions/fnc_addWaveHandler.sqf
+++ b/addons/ai/functions/fnc_addWaveHandler.sqf
@@ -9,20 +9,28 @@
  * 2: Global effect <BOOL>
  *
  * Return:
- * Nothing
+ * Event handler ID or nil if executed globally
  *
  * Description:
  * Adds an eventhandler to a wave spawner that execute everytime a wave is spawned.
  */
 
 params ["_logic","_code", ["_isGlobal",false]];
+TRACE_3("Adding wavehandler",_logic,_code,_isGlobal);
 
-if (_isGlobal && !isRemoteExecuted) exitWith {
-    [_logic,_code,false] remoteExecCall [QFUNC(addWaveHandler),0,true];
+if (_isGlobal && !isRemoteExecuted && isMultiplayer) then {
+    // Remote exec to everyone but the client
+    _this remoteExecCall [QFUNC(addWaveHandler),-clientOwner,true];
 };
 
 private _handlers = _logic getVariable ["Handlers", []];
-_handlers pushBack _code;
+private _index = _handlers pushBack _code;
 _logic setVariable ["Handlers", _handlers, false];
 
-nil
+// Return nil when executed globally,
+// as order cannot be ensured to be the same
+if !(_isGlobal) then {
+    _index
+} else {
+    nil
+}

--- a/addons/ai/functions/fnc_addWaveHandler.sqf
+++ b/addons/ai/functions/fnc_addWaveHandler.sqf
@@ -22,7 +22,7 @@ if (_isGlobal && !isRemoteExecuted) exitWith {
 };
 
 private _handlers = _logic getVariable ["Handlers", []];
-private _index = _handlers pushBack _code;
+_handlers pushBack _code;
 _logic setVariable ["Handlers", _handlers, false];
 
-//_index
+nil

--- a/addons/ai/functions/fnc_removeWaveHandler.sqf
+++ b/addons/ai/functions/fnc_removeWaveHandler.sqf
@@ -20,11 +20,11 @@ params ["_logic","_index"];
 TRACE_2("Removing wavehandler",_logic,_index);
 private _handlers = _logic getVariable ["Handlers", []];
 
-if (count _handlers < _index) exitWith {
-    WARNING_2("Failed removing wavehandler from %1 with ID %2",_index,_logic);
+if (isNil {_handlers # _index}) exitWith {
+    WARNING_2("Failed removing wavehandler from %1 with ID %2",_logic,_index);
     false
 };
 
-_handlers set [_index,{}];
+_handlers set [_index,nil];
 
 true

--- a/addons/ai/functions/fnc_removeWaveHandler.sqf
+++ b/addons/ai/functions/fnc_removeWaveHandler.sqf
@@ -1,7 +1,30 @@
-// Remove eventhandler from wave spawner
-// local only.
+#include "\x\tmf\addons\AI\script_component.hpp"
+/*
+ * Name: TMF_ai_fnc_removeWaveHandler
+ * Author: Head
+ *
+ * Arguments:
+ * 0: The wave spawner logic <OBJECT>
+ * 1: Event handler ID
+ *
+ * Return:
+ * Boolean, true if successfully removed.
+ *
+ * Description:
+ * Removes a wave spawner handle from an wave spawner
+ * Local only.
+ */
+
 params ["_logic","_index"];
-_hanlders = _logic getVariable ["Handlers", []];
-if(count _handlers < _index) exitWith {false};
-_hanlders set [_index,{}];
+
+TRACE_2("Removing wavehandler",_logic,_index);
+private _handlers = _logic getVariable ["Handlers", []];
+
+if (count _handlers < _index) exitWith {
+    WARNING_2("Failed removing wavehandler from %1 with ID %2",_index,_logic);
+    false
+};
+
+_handlers set [_index,{}];
+
 true

--- a/addons/ai/functions/fnc_spawnWave.sqf
+++ b/addons/ai/functions/fnc_spawnWave.sqf
@@ -120,7 +120,7 @@ _logic setVariable ["Waves", (_wave-1)];
 _handlers = _logic getVariable ["Handlers",[]];
 {
     if(_x isEqualType {}) then {
-        [_wave,_spawnedGroups,_spawnedUnits,_spawnedVehicles,_spawnedObjects,_logic] call _x;
+        [_wave,_spawnedGroups,_spawnedUnits,_spawnedVehicles,_spawnedObjects,_logic,_forEachIndex] call _x;
     };
 } forEach _handlers;
 // Check if there is another wave

--- a/addons/ai/functions/fnc_spawnWave.sqf
+++ b/addons/ai/functions/fnc_spawnWave.sqf
@@ -126,18 +126,14 @@ _handlers = _logic getVariable ["Handlers",[]];
 // Check if there is another wave
 if(_logic getVariable ["Waves",1] > 0) then {
     private _time = _logic getvariable ["Time",10];
-    private _whenDead = _logic getVariable ["WhenDead",false];
-    // Legacy support
-    if (_whenDead isEqualType false) then {
-        _whenDead = parseNumber _whenDead;
-    };
+    private _whenDead = _logic getVariable ["WhenDead",0];
 
     // Wait for conditions before spawning waves
     [
         {
             //params ["","","_minimumDead","_spawnedUnits", "_targetTime"];
             CBA_missionTime > (_this # 4) &&
-            {{!alive _x || lifeState _x isEqualTo "INCAPACITATED"} count (_this # 3) > (_this # 2)}
+            {{!alive _x || lifeState _x isEqualTo "INCAPACITATED"} count (_this # 3) >= (_this # 2)}
         },
         FUNC(spawnWave),
         [_logic,_spawnedGroups,_whenDead * count _spawnedUnits,_spawnedUnits, CBA_missionTime + _time]
@@ -147,4 +143,14 @@ if(_logic getVariable ["Waves",1] > 0) then {
     deleteVehicle _logic;
 };
 
-[format ["Spawned wave, unit count: %1, vehicle count: %2, group count %3, object count %4",count _spawnedUnits,count _spawnedVehicles,count _spawnedGroups, count _spawnedObjects],count _spawnedUnits > 40, "AI"] call EFUNC(adminmenu,log);
+[
+    format [
+        "Spawned wave, unit count: %1, vehicle count: %2, group count %3, object count %4",
+        count _spawnedUnits,
+        count _spawnedVehicles,
+        count _spawnedGroups,
+        count _spawnedObjects
+    ],
+    count _spawnedUnits > 40,
+    "AI"
+] call EFUNC(adminmenu,log);

--- a/addons/ai/functions/fnc_spawnWave.sqf
+++ b/addons/ai/functions/fnc_spawnWave.sqf
@@ -143,6 +143,8 @@ if(_logic getVariable ["Waves",1] > 0) then {
         [_logic,_spawnedGroups,_whenDead * count _spawnedUnits,_spawnedUnits, CBA_missionTime + _time]
     ] call CBA_fnc_waitUntilAndExecute;
 
+} else {
+    deleteVehicle _logic;
 };
 
 [format ["Spawned wave, unit count: %1, vehicle count: %2, group count %3, object count %4",count _spawnedUnits,count _spawnedVehicles,count _spawnedGroups, count _spawnedObjects],count _spawnedUnits > 40, "AI"] call EFUNC(adminmenu,log);

--- a/addons/ai/functions/fnc_spawnWave.sqf
+++ b/addons/ai/functions/fnc_spawnWave.sqf
@@ -63,7 +63,7 @@ _data params ['_groups', '_vehicles', '_objects'];
 
     private _grp = createGroup [_side, true]; // Delete group when empty
     {
-        _x params ["_type","_pos","_vectorDirAndUp","_gear", "_vehicleIndex", "_vehicleRole","_disabledAIFeatures"];
+        _x params ["_type","_pos","_vectorDirAndUp","_gear", "_vehicleIndex", "_vehicleRole"];
         private _unit = _grp createUnit [_type, [0,0,0],[] , 0, "NONE"];
         _spawnedUnits pushBack _unit;
         _unit setPosATL _pos;
@@ -98,10 +98,6 @@ _data params ['_groups', '_vehicles', '_objects'];
                 };
             };
         };
-
-        {
-            _unit disableAI _x;
-        } forEach _disabledAIFeatures;
     } forEach _units;
     (units _grp) join _grp;
      _lastIndex = (count waypoints _grp)-1;

--- a/addons/ai/functions/fnc_waveInit.sqf
+++ b/addons/ai/functions/fnc_waveInit.sqf
@@ -66,7 +66,7 @@ if(!(_logic getVariable [QGVAR(init),false])) then {
             private _data = [
                 typeOf _unit,
                 getPosATL _unit,
-                getDir _unit,
+                [vectorDir _x,vectorUp _x],
                 getUnitLoadout _unit,
                 -1,
                 [],
@@ -87,13 +87,13 @@ if(!(_logic getVariable [QGVAR(init),false])) then {
         typeOf _x,
         if (isSimpleObject _x) then [{getPosWorld _x},{getPosATL _x}],
         getDir _x,
-        vectorUp _x,
+        [vectorDir _x,vectorUp _x],
         isSimpleObject _x,
         simulationEnabled _x
     ]};
 
     // store vehicle data
-    _vehicles = _vehicles apply {[typeof _x,getposATL _x,getDir _x,[_x] call BIS_fnc_getVehicleCustomization, getPylonMagazines _x]};
+    _vehicles = _vehicles apply {[typeof _x,getposATL _x,[vectorDir _x,vectorUp _x],[_x] call BIS_fnc_getVehicleCustomization, getPylonMagazines _x]};
 
     _logic setVariable [QGVAR(waveData), [_groups, _vehicles, _cachedObjects]];
 

--- a/addons/ai/functions/fnc_waveInit.sqf
+++ b/addons/ai/functions/fnc_waveInit.sqf
@@ -24,6 +24,13 @@ if(count _headless > 0 && isServer) exitWith {
 
 // check if we have done the setup.
 if(!(_logic getVariable [QGVAR(init),false])) then {
+
+    // Legacy support
+    private _whenDead = _logic getVariable ["WhenDead",0];
+    if (_whenDead isEqualType false) then {
+        _logic setVariable ["WhenDead", parseNumber _whenDead, true];
+    };
+
     private _waves = _logic getVariable ["Waves", 1];
     if (_waves isEqualType "") then {
         _waves = parseNumber _waves;

--- a/addons/ai/functions/fnc_waveInit.sqf
+++ b/addons/ai/functions/fnc_waveInit.sqf
@@ -76,8 +76,7 @@ if(!(_logic getVariable [QGVAR(init),false])) then {
                 [vectorDir _x,vectorUp _x],
                 getUnitLoadout _unit,
                 -1,
-                [],
-                ALL_AI_FEATURES select {!(_unit checkAIFeature _x)}
+                []
             ];
             if(!isNull objectParent _x) then {
                 _data set [4, _vehicles find (objectParent _x)];

--- a/addons/ai/functions/fnc_waveInit.sqf
+++ b/addons/ai/functions/fnc_waveInit.sqf
@@ -82,7 +82,7 @@ if(!(_logic getVariable [QGVAR(init),false])) then {
     } forEach _synchronizedGroups;
 
     _objects = (_objects - _vehicles) - _allUnits;
-    _objects = _objects select {!(_x isKindOf "Logic")};
+    _objects = _objects select {side _x in [blufor,opfor,independent,civilian,sideUnknown] && !(_x isKindOf "EmptyDetector")};
     private _cachedObjects = _objects apply {[
         typeOf _x,
         if (isSimpleObject _x) then [{getPosWorld _x},{getPosATL _x}],

--- a/addons/ai/functions/fnc_waveInit.sqf
+++ b/addons/ai/functions/fnc_waveInit.sqf
@@ -25,6 +25,13 @@ if(count _headless > 0 && isServer) exitWith {
 // check if we have done the setup.
 if(!(_logic getVariable [QGVAR(init),false])) then {
     private _synchronizedGroups = [];
+    private _objects = synchronizedObjects _logic;
+    {
+        _x = getMissionLayerEntities _x;
+        _x params [["_layerObjects",[]]];
+
+        _objects append _layerObjects;
+    } forEach parseSimpleArray ("[" + (_logic getVariable ["Layers",""]) + "]");
     {
         if(_x isEqualType grpNull && {side _x in [blufor,opfor,independent,civilian]}) then {
             _synchronizedGroups pushBackUnique _x;
@@ -38,7 +45,8 @@ if(!(_logic getVariable [QGVAR(init),false])) then {
                } foreach crew _x;
            };
         };
-    } foreach synchronizedObjects _logic;
+    } foreach _objects;
+
     private _allUnits = [];
     { _allUnits append (units _x) } forEach _synchronizedGroups;
     private _vehicles = (_allUnits) apply {objectParent _x} select {!isNull _x};

--- a/addons/ai/modules/waveSpawner.hpp
+++ b/addons/ai/modules/waveSpawner.hpp
@@ -54,7 +54,11 @@ class GVAR(wavespawn) : Module_F {
             property = QGVAR(wavespawn_WaveInit);
             displayName = "Wave init code";
             tooltip = "Code executed every time a new wave is spawned";
-            expression = QUOTE([ARR_3(_this,compile _value,True)] call FUNC(addWaveHandler););
+            expression = QUOTE(                                                                                                                                                                \
+                if (_value != 'params [ARR_7(""_wave"",""_spawnedGroups"",""_spawnedUnits"",""_spawnedVehicles"",""_spawnedObjects"",""_logic"",""_wavehandlerID"")];' && _value != '') then { \
+                    [ARR_3(_this,compile _value,True)] call FUNC(addWaveHandler);                                                                                                              \
+                };                                                                                                                                                                             \
+            );
             defaultValue = "'params [""_wave"",""_spawnedGroups"",""_spawnedUnits"",""_spawnedVehicles"",""_spawnedObjects"",""_logic"",""_wavehandlerID""];'";
             control = "cba_common_EditCodeMulti10";
         };

--- a/addons/ai/modules/waveSpawner.hpp
+++ b/addons/ai/modules/waveSpawner.hpp
@@ -44,12 +44,25 @@ class GVAR(wavespawn) : Module_F {
             typeName = "NUMBER";
             defaultValue = 300;
         };
-        class WhenDead: Checkbox {
+        class WhenDead: Default {
             property = QGVAR(wavespawn_WhenDead);
-            displayName = "Previous wave must be dead";
-            tooltip = "Well should they?";
-            typeName = "BOOL";
-            defaultValue = "false";
+            displayName = "% Losses needed";
+            tooltip = "Percentage of units needing to be killed or unconscious before spawning a new wave";
+            control = "Slider";
+            typeName = "NUMBER";
+            defaultValue = 0;
+        };
+        class WaveInit: Default {
+            property = QGVAR(wavespawn_WaveInit);
+            displayName = "Wave init code";
+            tooltip = "Code executed every time a new wave is spawned";
+            expression = "                                              \
+                private _handlers = _this getVariable ['Handlers',[]];  \
+                _handlers pushBack compile _value;                      \
+                _this setVariable ['Handlers',_handlers,true];          \
+            ";
+            defaultValue = "'params [""_wave"",""_spawnedGroups"",""_spawnedUnits"",""_spawnedVehicles"",""_spawnedObjects"",""_logic""];'";
+            control = "cba_common_EditCodeMulti10";
         };
         class ModuleDescription: ModuleDescription {};
     };

--- a/addons/ai/modules/waveSpawner.hpp
+++ b/addons/ai/modules/waveSpawner.hpp
@@ -4,50 +4,57 @@ class GVAR(wavespawn) : Module_F {
     displayName = "Wave Spawner"; // Name displayed in the menu
 
     category = "Teamwork";
-    icon = "\x\tmf\addons\common\UI\logo_tmf_small_ca.paa";
+    icon = QPATHTOEF(common,UI\logo_tmf_small_ca.paa);
     // Name of function triggered once conditions are met
     function = QFUNC(waveInit);
-    // Execution priority, modules with lower number are executed first. 0 is used when the attribute is undefined
-    functionPriority = 0;
-    // 0 for server only execution, 1 for global execution, 2 for persistent global execution
-    isGlobal = 0;
-    // 1 for module waiting until all synced triggers are activated
-    isTriggerActivated = 1;
-    // 1 if modules is to be disabled once it's activated (i.e., repeated trigger activation won't work)
-    isDisposable = 0; // broken in EDEN;
+    functionPriority = 10;
+    isGlobal = false;
+    isTriggerActivated = true;
+    isDisposable = true;
 
-    // Menu displayed when the module is placed or double-clicked on by Zeus
-
-    class EventHandlers {
+    class EventHandlers: EventHandlers {
         init = "if(isServer && !is3DEN) then {[{_this call tmf_AI_fnc_waveInit;}, [_this select 0,[],false]] call CBA_fnc_execNextFrame;};_this call bis_fnc_moduleInit;";
     };
 
-    class Arguments: ArgumentsBaseUnits {
-        // Module specific arguments
-        class Delay {
-            displayName = "Execution delay";
-            description = "The time in seconds to wait before spawning the first wave";
-            typeName = "NUMBER";
-            defaultValue = "0";
+    class Attributes: AttributesBase {
+        class Layers: Edit {
+            property = QGVAR(wavespawn_Layers);
+            displayName = "Mission layers";
+            tooltip = "3DEN layers linked to this wavespawner. Format: ""Layer 1"", ""Layer 2"", ""etc""";
         };
-        class Waves {
-            displayName = "Number of waves"; // Argument label
-            description = ""; // Tooltip description
-            typeName = "NUMBER"; // Value type, can be "NUMBER", "STRING" or "BOOL"
+        class Delay: Default {
+            property = QGVAR(wavespawn_Delay);
+            displayName = "Execution delay";
+            tooltip = "The time in seconds to wait before spawning the first wave";
+            control = "SliderTime";
+            typeName = "NUMBER";
+            defaultValue = 0;
+        };
+        class Waves: Default {
+            displayName = "Number of waves";
+            property = QGVAR(wavespawn_Waves);
+            control = "EditShort";
+            expression = "_this setVariable ['Waves',parseNumber _value,true];";
+            typeName = "NUMBER";
             defaultValue = "1";
         };
-        class Time {
-            displayName = "Time between waves"; // Argument label
-            description = "In seconds."; // Tooltip description
-            typeName = "NUMBER"; // Value type, can be "NUMBER", "STRING" or "BOOL"
-            defaultValue = "10";
+        class Time: Default {
+            property = QGVAR(wavespawn_Time);
+            displayName = "Time between waves";
+            control = "SliderTime";
+            typeName = "NUMBER";
+            defaultValue = 300;
         };
-        class WhenDead {
-            displayName = "Previous wave must be dead"; // Argument label
-            description = "Well should they?"; // Tooltip description
-            typeName = "bool"; // Value type, can be "NUMBER", "STRING" or "BOOL"
+        class WhenDead: Checkbox {
+            property = QGVAR(wavespawn_WhenDead);
+            displayName = "Previous wave must be dead";
+            tooltip = "Well should they?";
+            typeName = "BOOL";
             defaultValue = "false";
         };
+        class ModuleDescription: ModuleDescription {};
     };
-    class ModuleDescription: ModuleDescription {};
+    class ModuleDescription: ModuleDescription {
+        description = "Caches and deletes synced units for spawning later, either when triggered or after time delay.<br/>Spawns units directly on headless clients if synchronized to them.";
+    };
 };

--- a/addons/ai/modules/waveSpawner.hpp
+++ b/addons/ai/modules/waveSpawner.hpp
@@ -54,11 +54,7 @@ class GVAR(wavespawn) : Module_F {
             property = QGVAR(wavespawn_WaveInit);
             displayName = "Wave init code";
             tooltip = "Code executed every time a new wave is spawned";
-            expression = "                                              \
-                private _handlers = _this getVariable ['Handlers',[]];  \
-                _handlers pushBack compile _value;                      \
-                _this setVariable ['Handlers',_handlers,true];          \
-            ";
+            expression = QUOTE([ARR_3(_this,compile _value,True)] call FUNC(addWaveHandler););
             defaultValue = "'params [""_wave"",""_spawnedGroups"",""_spawnedUnits"",""_spawnedVehicles"",""_spawnedObjects"",""_logic""];'";
             control = "cba_common_EditCodeMulti10";
         };

--- a/addons/ai/modules/waveSpawner.hpp
+++ b/addons/ai/modules/waveSpawner.hpp
@@ -34,9 +34,8 @@ class GVAR(wavespawn) : Module_F {
             displayName = "Number of waves";
             property = QGVAR(wavespawn_Waves);
             control = "EditShort";
-            expression = "_this setVariable ['Waves',parseNumber _value,true];";
             typeName = "NUMBER";
-            defaultValue = "1";
+            defaultValue = """1""";
         };
         class Time: Default {
             property = QGVAR(wavespawn_Time);

--- a/addons/ai/modules/waveSpawner.hpp
+++ b/addons/ai/modules/waveSpawner.hpp
@@ -1,16 +1,14 @@
 class GVAR(wavespawn) : Module_F {
-    // Standard object definitions
-    scope = 2; // Editor visibility; 2 will show it in the menu, 1 will hide it.
-    displayName = "Wave Spawner"; // Name displayed in the menu
+    scope = 2;
+    displayName = "Wave Spawner";
 
     category = "Teamwork";
     icon = QPATHTOEF(common,UI\logo_tmf_small_ca.paa);
-    // Name of function triggered once conditions are met
     function = QFUNC(waveInit);
     functionPriority = 10;
     isGlobal = false;
     isTriggerActivated = true;
-    isDisposable = true;
+    isDisposable = false;
 
     class EventHandlers: EventHandlers {
         init = "if(isServer && !is3DEN) then {[{_this call tmf_AI_fnc_waveInit;}, [_this select 0,[],false]] call CBA_fnc_execNextFrame;};_this call bis_fnc_moduleInit;";
@@ -20,7 +18,7 @@ class GVAR(wavespawn) : Module_F {
         class Layers: Edit {
             property = QGVAR(wavespawn_Layers);
             displayName = "Mission layers";
-            tooltip = "3DEN layers linked to this wavespawner. Format: ""Layer 1"", ""Layer 2"", ""etc""";
+            tooltip = "3DEN layers linked to this wavespawner.<br/>Format: ""Layer 1"", ""Layer 2"", ""etc""";
         };
         class Delay: Default {
             property = QGVAR(wavespawn_Delay);

--- a/addons/ai/modules/waveSpawner.hpp
+++ b/addons/ai/modules/waveSpawner.hpp
@@ -55,7 +55,7 @@ class GVAR(wavespawn) : Module_F {
             displayName = "Wave init code";
             tooltip = "Code executed every time a new wave is spawned";
             expression = QUOTE([ARR_3(_this,compile _value,True)] call FUNC(addWaveHandler););
-            defaultValue = "'params [""_wave"",""_spawnedGroups"",""_spawnedUnits"",""_spawnedVehicles"",""_spawnedObjects"",""_logic""];'";
+            defaultValue = "'params [""_wave"",""_spawnedGroups"",""_spawnedUnits"",""_spawnedVehicles"",""_spawnedObjects"",""_logic"",""_wavehandlerID""];'";
             control = "cba_common_EditCodeMulti10";
         };
         class ModuleDescription: ModuleDescription {};

--- a/addons/ai/modules/waveSpawner.hpp
+++ b/addons/ai/modules/waveSpawner.hpp
@@ -18,7 +18,7 @@ class GVAR(wavespawn) : Module_F {
         class Layers: Edit {
             property = QGVAR(wavespawn_Layers);
             displayName = "Mission layers";
-            tooltip = "3DEN layers linked to this wavespawner.<br/>Format: ""Layer 1"", ""Layer 2"", ""etc""";
+            tooltip = "3DEN layers linked to this wavespawner.\nFormat: ""Layer 1"", ""Layer 2"", ""etc""";
         };
         class Delay: Default {
             property = QGVAR(wavespawn_Delay);


### PR DESCRIPTION
* Add mission layers attribute (Resolves #372)
* Replace module arguments with 3DEN Attributes
* Change checking for dead waves to check for a percentage, and also account for unconscious units.
* Add wave init field, for more easily adding wave handler code.
* Add functionality for handling mission objects, simple objects and objects with simulation disabled
* Change from using `setDir` to `setVectorDirAndUp`
* Fix eventhandler inheritance (ref #360)

![image](https://user-images.githubusercontent.com/14627848/90537079-2d932100-e17d-11ea-8519-da670eeb7f9e.png)
