### PR TITLE
Add option for overriding player identity

### DIFF
--- a/addons/assigngear/XEH_PREP.sqf
+++ b/addons/assigngear/XEH_PREP.sqf
@@ -8,6 +8,7 @@ PREP(linkItems);
 PREP(loadFactions);
 PREP(loadFactionCategories);
 PREP(loadRoles);
+PREP(loadFaces);
 PREP(replaceEquipment);
 PREP(replacePrimaryWeapon);
 PREP(replaceSecondaryWeapon);

--- a/addons/assigngear/XEH_preInit.sqf
+++ b/addons/assigngear/XEH_preInit.sqf
@@ -3,6 +3,7 @@
 LOG("Preinit");
 
 #include "XEH_PREP.sqf"
+#include "initSettings.sqf"
 
 if (is3DEN) then {
     [] call FUNC(onEdenMissionChange);

--- a/addons/assigngear/XEH_preStart.sqf
+++ b/addons/assigngear/XEH_preStart.sqf
@@ -12,6 +12,7 @@ private _faceClasses = [];
 
 uiNamespace setVariable ["tmf_assignGear_validFaces",_faceClasses];
 
+
 {
     private _class = _x;
     private _name = configName _x;
@@ -31,6 +32,7 @@ uiNamespace setVariable ["tmf_assignGear_validFaces",_faceClasses];
 
     if (count _weightedArray > 0) then {
         uiNamespace setVariable ["tmf_assignGear_faceset_"+_name,_weightedArray];
+        TRACE_2("Cached faceset to uiNamespace",_name,_weightedArray);
     };
 } forEach ("true" configClasses (configFile >> "tmf_assignGear_facesets"));
 

--- a/addons/assigngear/functions/fnc_assignGear.sqf
+++ b/addons/assigngear/functions/fnc_assignGear.sqf
@@ -40,48 +40,51 @@ _unit setUnitLoadout (configFile >> 'EmptyLoadout');
 {
     if (!isNil "_x" && {!(_x isEqualTo [])} && {!(_x isEqualTo "")}) then {
         switch _forEachIndex do {
-            case 0: {}; // displayName
-            case 1: { // uniform
+            case IDX_DISPLAY_NAME: {}; // displayName
+            case IDX_OVERRIDE_PLAYER_IDENTITY: {
+                _unit setVariable [QGVAR(overridePlayerIdentity),(_x > 0)];
+            };
+            case IDX_UNIFORM: { // uniform
                 private _uniform = selectRandom _x;
                 if !(_uniform isEqualTo '') then {
                     _unit forceAddUniform _uniform;
                 };
             };
-            case 2: { // vest
+            case IDX_VEST: { // vest
                 private _vest = selectRandom _x;
                 if !(_vest isEqualTo '') then {
                     _unit addVest _vest;
                 };
             };
-            case 3: { // backpack
+            case IDX_BACKPACK: { // backpack
                 private _backpack = selectRandom _x;
                 if !(_backpack isEqualTo '') then {
                     _unit addBackpack _backpack;
                 };
             };
-            case 4: { // headgear
+            case IDX_HEADGEAR: { // headgear
                 private _headgear = selectRandom _x;
                 if !(_headgear isEqualTo '') then {
                     _unit addHeadgear _headgear;
                 };
             };
-            case 5: { // goggles
+            case IDX_GOGGLES: { // goggles
                 [_unit, _x] call FUNC(setGoggles);
             };
-            case 6: { // hmd
+            case IDX_HMD: { // hmd
                 private _hmd = selectRandom _x;
                 if !(_hmd isEqualTo '') then {_unit linkItem _hmd};
             };
-            case 7: { // faces
+            case IDX_FACES: { // faces
                 [_unit, _x] call FUNC(setFace);
             };
-            case 8: { // insignias
+            case IDX_INSIGNIAS: { // insignias
                 [_unit, selectRandom _x] call FUNC(setInsignia);
             };
-            case 9: { // backpackItems
+            case IDX_BACKPACK_ITEMS: { // backpackItems
                 {_unit addItemToBackpack _x} forEach _x;
             };
-            case 10: { // items
+            case IDX_ITEMS: { // items
                 { // Items try to fill uniform first
                     switch true do {
                         case (_unit canAddItemToUniform _x): {_unit addItemToUniform _x;};
@@ -90,7 +93,7 @@ _unit setUnitLoadout (configFile >> 'EmptyLoadout');
                     };
                 } forEach _x;
             };
-            case 11: { // magazines
+            case IDX_MAGAZINES: { // magazines
                 { // Magazines try to fill vest first
                     switch true do {
                         case (_unit canAddItemToVest _x): {_unit addItemToVest _x;};
@@ -99,49 +102,49 @@ _unit setUnitLoadout (configFile >> 'EmptyLoadout');
                     };
                 } forEach _x;
             };
-            case 12: { // linkedItems
+            case IDX_LINKED_ITEMS: { // linkedItems
                 {_unit addWeapon _x} forEach _x;
             };
-            case 13: { // primaryWeapon
+            case IDX_PRIMARY_WEAPON: { // primaryWeapon
                 private _weapon = selectRandom _x;
                 if !(_weapon isEqualTo '') then {_unit addWeapon _weapon};
             };
-            case 14: { // scope
+            case IDX_SCOPE: { // scope
                 private _scope = selectRandom _x;
                 if !(_scope isEqualTo '') then {_unit addPrimaryWeaponItem _scope};
             };
-            case 15: { // bipod
+            case IDX_BIPOD: { // bipod
                 private _bipod = selectRandom _x;
                 if !(_bipod isEqualTo '') then {_unit addPrimaryWeaponItem _bipod};
             };
-            case 16: { // attachment
+            case IDX_ATTACHMENT: { // attachment
                 private _attachment = selectRandom _x;
                 if !(_attachment isEqualTo '') then {_unit addPrimaryWeaponItem _attachment};
             };
-            case 17: { // silencer
+            case IDX_SILENCER: { // silencer
                 private _silencer = selectRandom _x;
                 if !(_silencer isEqualTo '') then {_unit addPrimaryWeaponItem _silencer};
             };
-            case 18: { // secondaryWeapon
+            case IDX_SECONDARY_WEAPON: { // secondaryWeapon
                 private _weapon = selectRandom _x;
                 if !(_weapon isEqualTo '') then {_unit addWeapon _weapon};
             };
-            case 19: { // secondaryAttachments
+            case IDX_SECONDARY_ATTACHMENTS: { // secondaryAttachments
                 {_unit addSecondaryWeaponItem _x} forEach _x;
             };
-            case 20: { // sidearmweapon
+            case IDX_SIDEARM_WEAPON: { // sidearmweapon
                 private _weapon = selectRandom _x;
                 if !(_weapon isEqualTo '') then {_unit addWeapon _weapon};
             };
-            case 21: { // sidearmattachments
+            case IDX_SIDEARM_ATTACHMENTS: { // sidearmattachments
                 {_unit addHandgunItem _x} forEach _x;
             };
-            case 22: { // Unit traits
+            case IDX_TRAITS: { // Unit traits
                 {
                     [_unit, _x] call FUNC(setUnitTrait);
                 } forEach _x;
             };
-            case 23: { // code
+            case IDX_CODE: { // code
                 _unit call compile _x;
             };
         };

--- a/addons/assigngear/functions/fnc_loadAssignGear.sqf
+++ b/addons/assigngear/functions/fnc_loadAssignGear.sqf
@@ -56,7 +56,12 @@ private _loadoutArray = [];
             _loadoutArray set [IDX_GOGGLES, _goggles];
         };
         CASE("hmd",IDX_HMD);
-        CASE("faces",IDX_FACES);
+        case "faces": {
+            _loadoutArray set [
+                IDX_FACES,
+                (_x call BIS_fnc_getCfgData) call FUNC(loadFaces)
+            ];
+        };
         CASE("insignias",IDX_INSIGNIAS);
 
         // Items/magazines

--- a/addons/assigngear/functions/fnc_loadAssignGear.sqf
+++ b/addons/assigngear/functions/fnc_loadAssignGear.sqf
@@ -15,7 +15,6 @@
  * Loads assigngear from config
  */
 #define CFGROLE (_cfg >> "CfgLoadouts" >> _faction >> _role)
-#define CFGPARSE (configFile >> "CfgLoadoutsParser")
 
 params [
     "_faction",
@@ -43,41 +42,42 @@ private _loadoutArray = [];
 {
     switch (toLower configName _x) do {
         // Equipment/appearance
-        CASE("displayname",0);
-        CASE("uniform",1);
-        CASE("vest",2);
-        CASE("backpack",3);
-        CASE("headgear",4);
+        CASE("displayname",IDX_DISPLAY_NAME);
+        CASE("overrideplayeridentity",IDX_OVERRIDE_PLAYER_IDENTITY);
+        CASE("uniform",IDX_UNIFORM);
+        CASE("vest",IDX_VEST);
+        CASE("backpack",IDX_BACKPACK);
+        CASE("headgear",IDX_HEADGEAR);
         case "goggles": {
             private _goggles = _x call BIS_fnc_getCfgData;
             if (_goggles isEqualTo []) then {
                 _goggles pushBack ""; // an empty array would mean goggles being skipped in main assignGear function
             };
-            _loadoutArray set [5, _goggles];
+            _loadoutArray set [IDX_GOGGLES, _goggles];
         };
-        CASE("hmd",6);
-        CASE("faces",7);
-        CASE("insignias",8);
+        CASE("hmd",IDX_HMD);
+        CASE("faces",IDX_FACES);
+        CASE("insignias",IDX_INSIGNIAS);
 
         // Items/magazines
-        CASE("backpackitems",9);
-        CASE("items",10);
-        CASE("magazines",11);
-        CASE("linkeditems",12);
+        CASE("backpackitems",IDX_BACKPACK_ITEMS);
+        CASE("items",IDX_ITEMS);
+        CASE("magazines",IDX_MAGAZINES);
+        CASE("linkeditems",IDX_LINKED_ITEMS);
 
         // Weapons
-        CASE("primaryweapon",13);
-        CASE("scope",14);
-        CASE("bipod",15);
-        CASE("attachment",16);
-        CASE("silencer",17);
-        CASE("secondaryweapon",18);
-        CASE("secondaryattachments",19);
-        CASE("sidearmweapon",20);
-        CASE("sidearmattachments",21);
+        CASE("primaryweapon",IDX_PRIMARY_WEAPON);
+        CASE("scope",IDX_SCOPE);
+        CASE("bipod",IDX_BIPOD);
+        CASE("attachment",IDX_ATTACHMENT);
+        CASE("silencer",IDX_SILENCER);
+        CASE("secondaryweapon",IDX_SECONDARY_WEAPON);
+        CASE("secondaryattachments",IDX_SECONDARY_ATTACHMENTS);
+        CASE("sidearmweapon",IDX_SIDEARM_WEAPON);
+        CASE("sidearmattachments",IDX_SIDEARM_ATTACHMENTS);
 
-        CASE("traits",22);
-        CASE("code",23);
+        CASE("traits",IDX_TRAITS);
+        CASE("code",IDX_CODE);
     };
 } forEach configProperties [CFGROLE];
 

--- a/addons/assigngear/functions/fnc_loadFaces.sqf
+++ b/addons/assigngear/functions/fnc_loadFaces.sqf
@@ -1,0 +1,54 @@
+#include "\x\tmf\addons\assignGear\script_component.hpp"
+/* ----------------------------------------------------------------------------
+Internal Function: TMF_assigngear_fnc_loadFaces
+
+Description:
+    Parses an array with facesets
+
+Parameters:
+    _faces - An array containing face classes and facesets [Array]
+
+Returns:
+    Weighted array of faces
+
+Author:
+    Freddo, Nick
+---------------------------------------------------------------------------- */
+
+private _weightedArr = [];
+
+{
+    if (_x isEqualType "") then {
+        _x = toLower _x;
+
+        if ((_x find "faceset:") == 0) then {
+            // faceset
+            TRACE_1("Loading faceset",_x);
+
+            private _arr = uiNamespace getVariable [
+                format [QGVAR(faceset_%1),_x select [8]],
+                ["",0]
+            ];
+
+            if (_arr isEqualTo ["",0]) then {
+                ERROR_1("Faceset error in: %1",_x);
+            };
+
+            _weightedArr append _arr
+        } else {
+            // Simple entry
+            TRACE_1("Appending face to face array",_x);
+            _weightedArr append [_x, 1];
+        };
+    } else {
+        // Simple weighted already
+        if (_x isEqualTypeArray ["",-1]) then {
+            TRACE_1("Appending weighted face array to face array",_x);
+            _weightedArr append _x;
+        } else {
+            ERROR_1("Error in weighted face array: %1",_x);
+        };
+    };
+} forEach _this;
+
+_weightedArr

--- a/addons/assigngear/functions/fnc_overrideProfileItems.sqf
+++ b/addons/assigngear/functions/fnc_overrideProfileItems.sqf
@@ -1,7 +1,7 @@
 #include "\x\tmf\addons\assignGear\script_component.hpp"
 /*
  * Name = TMF_assignGear_fnc_overrideProfileItems
- * Author = Bear
+ * Author = Bear, Freddo
  *
  * Description:
  * Override face and goggles set by player profile with loadout definitions
@@ -9,21 +9,24 @@
 
 ["CBA_loadingScreenDone", { // should ensure profile is overridden https://github.com/CBATeam/CBA_A3/wiki/Loading-Screen-Event-Handler
     [{
-        private _faction = player getVariable [QGVAR(faction), ""];
-        if (_faction isEqualTo "") exitWith {};
+        if !(player getVariable [QGVAR(done),false]) exitWith {};
+        if !(player getVariable [QGVAR(overridePlayerIdentity),GVAR(overridePlayerIdentity)]) exitWith {};
 
-        private _cfg = configFile >> "CfgLoadouts" >> _faction >> (player getVariable [QGVAR(role), ""]);
-
-        private _faces = getArray (_cfg >> "faces");
+        private _faces = player getVariable [QGVAR(faces),[]];
         if !(_faces isEqualTo []) then {
             [player, _faces] call FUNC(setFace);
         };
 
-        private _goggles = getArray (_cfg >> "goggles");
+        private _goggles = player getVariable [QGVAR(goggles),[]];
         if !(_goggles isEqualTo []) then {
             [player, _goggles] call FUNC(setGoggles);
         } else {
             removeGoggles player;
         };
-    }, 1, 1] call CBA_fnc_waitAndExecute;
+
+        private _insignia = player getVariable [QGVAR(insignia),"default"];
+        [player,_insignia] call FUNC(setInsignia);
+
+        TRACE_3("Overriden player profile items",_faces,_goggles,_insignia);
+    }, [], 2] call CBA_fnc_waitAndExecute;
 }] call CBA_fnc_addEventHandler;

--- a/addons/assigngear/functions/fnc_setFace.sqf
+++ b/addons/assigngear/functions/fnc_setFace.sqf
@@ -1,11 +1,11 @@
 #include "\x\tmf\addons\assignGear\script_component.hpp"
 /*
  * Name = TMF_assignGear_fnc_setFace
- * Author = Nick
+ * Author = Nick, Freddo
  *
  * Arguments:
  * 0: Object. Unit
- * 1: ARRAY. Array of faces to choose from
+ * 1: ARRAY. Weighted array of faces to choose from
  *
  * Description:
  * Will set a units face to a randomly chosen one from the supplied list.
@@ -13,31 +13,26 @@
 params ["_unit","_faces"];
 
 _unit setVariable [QGVAR(faces),_faces];
-if (_faces isEqualTo []) exitWith {};
 
-private _unitFace = toLower (face _unit);
-private _hasValidFace = false;
+if (
+    isPlayer _unit &&
+    { !(_unit getVariable [QGVAR(overridePlayerIdentity),GVAR(overridePlayerIdentity) ]) }
+) exitWith {
+    TRACE_1("Kept default face for unit",_unit);
+};
 
-{
-    if ((_x find "faceset:") isEqualTo 0) then {
-        private _facesetName = _x select [8];
-        private _array = uiNamespace getVariable ["tmf_assignGear_faceset_" + _facesetName, []];
-        if (_unitFace in _array) exitWith { _hasValidFace = true; };
-    } else {
-        if (_unitFace isEqualTo (toLower _x)) exitWith { _hasValidFace = true; };
-    };
-} forEach _faces;
+if (
+    _faces isEqualTo [] ||
+    (toLower face _unit) in _faces
+) exitWith {
+    TRACE_1("Kept default face for unit",_unit);
+};
 
-if (_hasValidFace) exitWith {};
+private _face = selectRandomWeighted _faces;
 
-private _face = selectRandom _faces;
-
-if ((_face find "faceset:") isEqualTo 0) then {
-    private _facesetName = _face select [8];
-    private _array = uiNamespace getVariable ["tmf_assignGear_faceset_" + _facesetName, []];
-    if !(_array isEqualTo []) then {
-        _face = selectRandomWeighted _array;
-    };
+if (_face == "Default") exitWith {
+    TRACE_1("Kept default face for unit",_unit);
 };
 
 [_unit, _face] remoteExec ["setFace", 0, _unit];
+TRACE_2("Set face for unit",_unit,_face);

--- a/addons/assigngear/functions/fnc_setFace.sqf
+++ b/addons/assigngear/functions/fnc_setFace.sqf
@@ -12,6 +12,7 @@
  */
 params ["_unit","_faces"];
 
+_unit setVariable [QGVAR(faces),_faces];
 if (_faces isEqualTo []) exitWith {};
 
 private _unitFace = toLower (face _unit);

--- a/addons/assigngear/functions/fnc_setGoggles.sqf
+++ b/addons/assigngear/functions/fnc_setGoggles.sqf
@@ -13,20 +13,14 @@
 
 params ["_unit", "_goggles"];
 
+_unit setVariable [QGVAR(goggles),_goggles];
 private _curGoggles = goggles _unit;
-if (_curGoggles isEqualTo "") then { // Don't respect no-goggles profile in skip check
-    _curGoggles = "givemegoggles";
-};
 
 // Skip if loadout allows profile glasses OR profile glasses part of loadout
 if ("default" in _goggles || _curGoggles in _goggles) exitWith {};
 
-private _newGoggles = ""; 
-if !(_goggles isEqualTo []) then {
-    _newGoggles = selectRandom _goggles;
-};
-
-if (_newGoggles isEqualTo "") then {
+private _newGoggles = selectRandom _goggles;
+if (isNil "_newGoggles" || {_newGoggles isEqualTo ""}) then {
     removeGoggles _unit;
 } else {
     _unit addGoggles _newGoggles;

--- a/addons/assigngear/functions/fnc_setInsignia.sqf
+++ b/addons/assigngear/functions/fnc_setInsignia.sqf
@@ -16,19 +16,10 @@
  * Note:
  * Thanks @Bear and @Nick for helping
  */
-params ["_unit","_insignia"];
+params ["_unit",["_insignia","default"]];
 
-if (time > 5 || {is3DEN}) then
-{
-    [_unit, _insignia] call BIS_fnc_setUnitInsignia;
-}
-else
-{
-    // Wait until game has started to overwrite player insignias
-    [
-        BIS_fnc_isLoading,
-        BIS_fnc_setUnitInsignia,
-        [_unit, _insignia],
-        5
-    ] call CBA_fnc_waitUntilAndExecute;
-};
+if (_insignia == "default") exitWith {};
+
+[_unit, _insignia] call BIS_fnc_setUnitInsignia;
+
+_unit setVariable [QGVAR(insignia),_insignia];

--- a/addons/assigngear/initSettings.sqf
+++ b/addons/assigngear/initSettings.sqf
@@ -1,0 +1,8 @@
+[
+    QGVAR(overridePlayerIdentity),
+    "CHECKBOX",
+    ["Override player identity", "Toggles whether assigngear will override player identity by default. Can still be overriden in the loadout config."],
+    ["TMF", "Assigngear"],
+    true,
+    true
+] call CBA_fnc_addSetting;

--- a/addons/assigngear/loadouts/blu_f.hpp
+++ b/addons/assigngear/loadouts/blu_f.hpp
@@ -5,10 +5,17 @@ class baseMan {// Weaponless baseclass
     vest[] = {"V_PlateCarrier1_rgr","V_PlateCarrier2_rgr"};
     backpack[] = {"B_AssaultPack_mcamo"};
     headgear[] = {};
-    goggles[] = {"default"};
+    goggles[] =
+    {
+        LIST_4("default"),
+        "G_Combat",
+        "G_Tactical_Clear",
+        "G_Tactical_Black",
+        LIST_4("")
+    };
     hmd[] = {};
     // Leave empty to remove all. "Default" > leave original item.
-    faces[] = {"faceset:african", "faceset:caucasian"};
+    faces[] = {"faceset:american"};
     // Leave empty to not change faces.
     insignias[] = {"111thID"};
     // Leave empty to not change insignias

--- a/addons/assigngear/script_component.hpp
+++ b/addons/assigngear/script_component.hpp
@@ -43,6 +43,32 @@
 #define LIST_19(var1) var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1
 #define LIST_20(var1) var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1,var1
 
+/* assignGear cache indexes */
+#define IDX_DISPLAY_NAME 0
+#define IDX_OVERRIDE_PLAYER_IDENTITY 1
+#define IDX_UNIFORM 2
+#define IDX_VEST 3
+#define IDX_BACKPACK 4
+#define IDX_HEADGEAR 5
+#define IDX_GOGGLES 6
+#define IDX_HMD 7
+#define IDX_FACES 8
+#define IDX_INSIGNIAS 9
+#define IDX_BACKPACK_ITEMS 10
+#define IDX_ITEMS 11
+#define IDX_MAGAZINES 12
+#define IDX_LINKED_ITEMS 13
+#define IDX_PRIMARY_WEAPON 14
+#define IDX_SCOPE 15
+#define IDX_BIPOD 16
+#define IDX_ATTACHMENT 17
+#define IDX_SILENCER 18
+#define IDX_SECONDARY_WEAPON 19
+#define IDX_SECONDARY_ATTACHMENTS 20
+#define IDX_SIDEARM_WEAPON 21
+#define IDX_SIDEARM_ATTACHMENTS 22
+#define IDX_TRAITS 23
+#define IDX_CODE 24
 
 #define FILTER_WEAPON 0
 #define FILTER_GEAR 1

--- a/tmf_template.vr/description.ext
+++ b/tmf_template.vr/description.ext
@@ -44,6 +44,7 @@ class CfgLoadouts
     class EXAMPLE_LOADOUT
     {
         displayName = "Example Loadout";
+        tooltip = "My tooltip\nNew line";
         #include "loadouts\example_loadout.hpp"
     };
 };

--- a/tmf_template.vr/loadouts/example_loadout.hpp
+++ b/tmf_template.vr/loadouts/example_loadout.hpp
@@ -8,6 +8,7 @@ class baseMan {// Weaponless baseclass
     goggles[] = {"default"};
     hmd[] = {};
     // Leave empty to remove all. "Default" > leave original item.
+    // overridePlayerIdentity = 1; // Uncomment to override CBA setting
     faces[] = {"faceset:african", "faceset:caucasian"};
     // Leave empty to not change faces.
     insignias[] = {"111thID"};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14627848/90557698-3561be00-e19b-11ea-9ef0-abd22e27be7d.png)

This setting can be overridden by setting `overwritePlayerIdentity = 1` in config, though if not set defaults to the above setting.


Also added assigngear index macros, credits to @Boberro 