### PR TITLE
Swap variable sync to CBA events

### DIFF
--- a/addons/common/XEH_preInit.sqf
+++ b/addons/common/XEH_preInit.sqf
@@ -8,3 +8,14 @@ if is3DEN call {
 };
 
 isTMF = ((getMissionConfigValue ["tmf_version",[0,0,0]] select 0) > 0);
+
+// Rig up server event handler for variable sync requests.
+if (isServer) then {
+    [QGVAR(requestServerSync), {
+        // Delay a frame.
+        [{
+            params ["_clientOwnerId"];
+            [QGVAR(serverVariableSyncResponse), [], _clientOwnerId] call CBA_fnc_ownerEvent;
+        }, _this] call CBA_fnc_execNextFrame;
+    }] call CBA_fnc_addEventHandler;
+};


### PR DESCRIPTION
**What this Pull Request Does**
- An issue we currently have in rare cases for JIPs is that sometimes the variable sync variable is sent too early in the JIP message queue. This could mean wrongly assigned radios/orbat being incorrect as those systems for the sync to finish. This due to the sever arbitrarily sending the message. I swapped this to an event driven approach which should remove the issue for JIPs.
- Address #327 