### PR TITLE
Fix params syntax for init field test

### DIFF
--- a/addons/autotest/functions/fnc_testInit.sqf
+++ b/addons/autotest/functions/fnc_testInit.sqf
@@ -17,7 +17,7 @@
 private _output = [];
 
 {
-    (_x get3DENAttribute 'Init') params ["_init",""];
+    private _init = toLower ((_x get3DENAttribute 'Init') param [0,""]);
     _init = toLower _init;
     private _count = count _init;
     private _VA = (_init find "exported from arsenal") >= 0;

--- a/addons/autotest/functions/fnc_testInit.sqf
+++ b/addons/autotest/functions/fnc_testInit.sqf
@@ -18,7 +18,6 @@ private _output = [];
 
 {
     private _init = toLower ((_x get3DENAttribute 'Init') param [0,""]);
-    _init = toLower _init;
     private _count = count _init;
     private _VA = (_init find "exported from arsenal") >= 0;
     private _isServer = (_init find "isserver") >= 0;


### PR DESCRIPTION
Looks like it was supposed to be default value `""`, but it was missing some square brackets. Replaced `params` with single `param`, as `get3DENAttribute` returns a single entry array.

Tested locally in debug console