### PR TITLE
Fix spectator JIP setting

### DIFF
--- a/addons/spectator/XEH_clientPostInit.sqf
+++ b/addons/spectator/XEH_clientPostInit.sqf
@@ -2,42 +2,45 @@
 
 LOG("Client PostInit started");
 
-if (player isKindOf QGVAR(unit)) exitWith {};
+["CBA_settingsInitialized", {
 
-[{
-    // Check if JIP is allowed, if not then kill the JIP player.
-    private _isAIunit = player getVariable [QGVAR(isJIPable),false];
-    private _isJIPAllowed = switch (GVAR(isJIPAllowed)) do {
-        case 0: {false};
-        case 1: {true};
-        case 2: {[] call EFUNC(safestart,isActive)};
-    };
-    private _templateActive = (
-        "TMF_Spectator" in getMissionConfigValue ["respawnTemplates",[]] &&
-        1 isEqualTo getMissionConfigValue ["Respawn",-1]
-    );
+    [{
+        if (player isKindOf QGVAR(unit)) exitWith {};
 
-    TRACE_5("Check JIP conditions",_templateActive, _isJIPAllowed, _isAIunit, CBA_missionTime, didJIP);
-    TRACE_1("Check JIP conditions 2",(_templateActive && !(_isJIPAllowed || _isAIunit) && CBA_missionTime > 5 && didJIP));
+        // Check if JIP is allowed, if not then kill the JIP player.
+        private _isAIunit = player getVariable [QGVAR(isJIPable),false];
+        private _isJIPAllowed = switch (GVAR(isJIPAllowed)) do {
+            case 0: {false};
+            case 1: {true};
+            case 2: {[] call EFUNC(safestart,isActive)};
+        };
+        private _templateActive = (
+            "TMF_Spectator" in getMissionConfigValue ["respawnTemplates",[]] &&
+            1 isEqualTo getMissionConfigValue ["Respawn",-1]
+        );
 
-    if (_templateActive && !(_isJIPAllowed || _isAIunit) && CBA_missionTime > 5 && didJIP) then {
-        LOG("JIP: True");
+        TRACE_5("Check JIP conditions",_templateActive, _isJIPAllowed, _isAIunit, CBA_missionTime, didJIP);
+        TRACE_1("Check JIP conditions 2",(_templateActive && !(_isJIPAllowed || _isAIunit) && CBA_missionTime > 5 && didJIP));
 
-        [{!isNull player && {!([] call BIS_fnc_isLoading)}},{
-            LOG_1("JIP: killing %1", player);
-            [player, objNull, true] spawn {
-                private _oldObject = _this # 0;
-                _this call FUNC(init);
-                systemChat "You joined the mission in progress. Entering spectator.";
-                [format ["Player JIP to spectator: %1", profileName],true,"Spectator"] call EFUNC(adminmenu,log);
-                deleteVehicle _oldObject;
-            };
-        }] call CBA_fnc_waitUntilAndExecute;
+        if (_templateActive && !(_isJIPAllowed || _isAIunit) && CBA_missionTime > 5 && didJIP) then {
+            LOG("JIP: True");
 
-    };
+            [{!isNull player && {!([] call BIS_fnc_isLoading)}},{
+                LOG_1("JIP: killing %1", player);
+                [player, objNull, true] spawn {
+                    private _oldObject = _this # 0;
+                    _this call FUNC(init);
+                    systemChat "You joined the mission in progress. Entering spectator.";
+                    [format ["Player JIP to spectator: %1", profileName],true,"Spectator"] call EFUNC(adminmenu,log);
+                    deleteVehicle _oldObject;
+                };
+            }] call CBA_fnc_waitUntilAndExecute;
 
-// Add a small delay for things to synchronize
-},[], 0.1] call CBA_fnc_waitAndExecute;
+        };
+
+    // Add a small delay for things to synchronize
+    },[], 0.1] call CBA_fnc_waitAndExecute;
+}] call CBA_fnc_addEventHandler;
 
 // Hide ST HUD if spectator is OPEN
 if (isClass (configfile >> "CfgPatches" >> "STUI_GroupHUD")) then {


### PR DESCRIPTION
Appears that CBA settings don't have time to synchronise. Putting it behind a "CBA_settingsInitialized" eventhandler should solve it.

Fixes #341