### PR TITLE
Fix inability to claim Zeus mid-mission in some missions

### DIFF
--- a/addons/adminmenu/XEH_postServerInit.sqf
+++ b/addons/adminmenu/XEH_postServerInit.sqf
@@ -80,3 +80,13 @@ if (isMultiplayer) then {
         };
     }];
 };
+
+
+if (isNil QGVAR(sideCenter)) then {
+    GVAR(sideCenter) = createCenter sideLogic;
+};
+
+GVAR(zeusGroup) = createGroup GVAR(sideCenter);
+if (isNull GVAR(zeusGroup)) then {
+    GVAR(zeusGroup) = createGroup civilian;
+};

--- a/addons/adminmenu/functions/fnc_makeZeusServer.sqf
+++ b/addons/adminmenu/functions/fnc_makeZeusServer.sqf
@@ -27,11 +27,7 @@ private _isValidCurator = false;
 } forEach allCurators;
 
 if (!_isValidCurator) then {
-    if (isNil QGVAR(sideCenter)) then {
-        GVAR(sideCenter) = createCenter sideLogic;
-    };
-
-    private _curator = (createGroup GVAR(sideCenter)) createUnit ["ModuleCurator_F", [0,0,0], [], 0, "NONE"];
+    private _curator = GVAR(zeusGroup) createUnit ["ModuleCurator_F", [0,0,0], [], 0, "NONE"];
     _curator setVariable ["Addons", 3, true];
     _curator setVariable [QGVAR(zeus), true, true];
     _curator setVariable ["showNotification", false, true];


### PR DESCRIPTION
**What this Pull Request does:**
- Fix inability to claim Zeus mid-mission in some missions. Sometimes the group limit for sideLogic would be reached mid-mission. This PR swaps it from creating groups on demand for Zeuses but instead reserves a group at start of mission 