### PR TITLE
Remove TMF slotting group names

### DIFF
--- a/addons/common/CfgEventHandlers.hpp
+++ b/addons/common/CfgEventHandlers.hpp
@@ -20,9 +20,6 @@ class Extended_Respawn_EventHandlers {
 };
 
 class Extended_DisplayLoad_EventHandlers {
-    class RscDisplayMultiplayerSetup {
-        tmf_slotting = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayMultiplayerSetup)'));
-    };
     class RscDisplayDebriefing {
         tmf_override_end_text = QUOTE(_this call (uiNamespace getVariable 'FUNC(initDisplayDebriefing)'));
     };

--- a/addons/common/XEH_PREP.sqf
+++ b/addons/common/XEH_PREP.sqf
@@ -35,7 +35,6 @@ PREP(edenHideMapObjects);
 PREP(hideMapObjectsInit);
 PREP(getPosVisual);
 PREP(initDisplayDebriefing);
-PREP(initDisplayMultiplayerSetup);
 PREP(testGroupsSlottingScreen);
 PREP(secondsToTime);
 PREP(edenDisplayFactionIcons);

--- a/addons/common/functions/fnc_testGroupsSlottingScreen.sqf
+++ b/addons/common/functions/fnc_testGroupsSlottingScreen.sqf
@@ -14,66 +14,18 @@
 
 private _output = [];
 
-// Deprecated in newer versions, replaced by CBA system
-// https://github.com/CBATeam/CBA_A3/wiki/Name-Groups-in-Lobby
-if ([[1,1,0]] call FUNC(checkTMFVersion)) then {
-    // Find groups with playableUnits
-    private _groups = [];
-    {_groups pushBackUnique (group _x);} forEach playableUnits;
 
-    private _outputGroups = [];
-    {
-        private _group = _x;
-        private _descriptions = [];
-        private _skip = false;
-        {
-            private _description = (_x get3DENAttribute "description") select 0;
-            if (_description find "@" != -1) exitWith {_skip = true};
-            _descriptions pushBack _description;
-        } forEach (units _group select {_x in playableUnits});
-        if (!_skip) then {
-            _descriptions = _descriptions apply {(/*toLower*/ _x) splitString " "};
-            if (count (units _group) > 1) then {
-                private _common = _descriptions select 0;
-                {
-                    // Ensure common is not more tokens than the present description.
-                    _common resize ((count _x) min (count _common));
-                    for "_idx2" from 0 to (count _common -1) do {
-                        //diag_log str [_idx2,"c",_common,"d",_descriptions];
-                        if (_common select _idx2 != _x select _idx2) exitWith { _common resize _idx2;}
-                    };
-                } forEach _descriptions;
-                //diag_log str ["group",_common,"d",_descriptions];
-                //_common = _common apply {/*toUpper*/ (_x select [0,1]) + (_x select [1])};
-                if (count _common == 0) then {
-                    // No common part.
-                    _outputGroups pushBackUnique _group;
-                };
-            };
+private _units = playableUnits + [player] - [objNull];
+{
+    private _desc = (_x get3DENAttribute "description") # 0;
+
+    if (_desc isEqualTo "") then {
+        _output pushBack [1,format ["Unit lacks role description: %1",_x]];
+    } else {
+        if !("@" in _desc) then {
+            _output pushBack [1,format ["Unit lacks slotting group name: %1 (should be: %1@Group Name)", _desc]];
         };
-    } forEach _groups;
-
-    if (count _outputGroups > 0) then {
-        _output pushBack [1,"Some groups do not have a slotting screen name:"];
-        private _string = "";
-        {
-            _string = _string + ((side _x) call BIS_fnc_sideName) + " - " + groupID _x + ", ";
-        } forEach _outputGroups;
-        _output pushBack [1,format ["groups (%1): %2",count _outputGroups,_string]];
     };
-} else {
-    private _units = (playableUnits + [player]);
-    {
-        private _desc = (_x get3DENAttribute "description") # 0;
-
-        if (_desc isEqualTo "") then {
-            _output pushBack [1,format ["Unit lacks role description: %1",_x]];
-        } else {
-            if !("@" in _desc) then {
-                _output pushBack [1,format ["Unit lacks slotting group name: %1 (should be: %1@Group Name)", _desc]];
-            };
-        };
-    } forEach (playableUnits + [player]);
-};
+} forEach (playableUnits + [player]);
 
 _output

--- a/addons/common/functions/fnc_testGroupsSlottingScreen.sqf
+++ b/addons/common/functions/fnc_testGroupsSlottingScreen.sqf
@@ -14,8 +14,6 @@
 
 private _output = [];
 
-
-private _units = playableUnits + [player] - [objNull];
 {
     private _desc = (_x get3DENAttribute "description") # 0;
 
@@ -26,6 +24,6 @@ private _units = playableUnits + [player] - [objNull];
             _output pushBack [1,format ["Unit lacks slotting group name: %1 (should be: %1@Group Name)", _desc]];
         };
     };
-} forEach (playableUnits + [player]);
+} forEach (playableUnits + [player] - [objNull]);
 
 _output


### PR DESCRIPTION
Workaround version check solution seemingly doesn't work on remote servers. CBA implementation has been in the template for a while now.

If this isn't an option then I might revive #336