### PR TITLE
Fix hemtt template submodule error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".hemtt/template"]
+	path = .hemtt/template
+	url = https://github.com/hemtt/cba.git


### PR DESCRIPTION
Causes problems when you have TMF added as a submodule.

https://github.com/ARCOMM/arc_misc/pull/136