### PR TITLE
Print autotest output to rpt

### DIFF
--- a/addons/autotest/XEH_preInit.sqf
+++ b/addons/autotest/XEH_preInit.sqf
@@ -1,3 +1,4 @@
 #include "script_component.hpp"
 
 #include "XEH_PREP.sqf"
+#include "initSettings.sqf"

--- a/addons/autotest/functions/fnc_autotest.sqf
+++ b/addons/autotest/functions/fnc_autotest.sqf
@@ -13,8 +13,8 @@ private _output = [];
 
     private _outputTest = call compile _code;
     if (_outputTest isEqualType []) then {
-        if (_output isNotEqualTo []) then {
-            diag_log _outputTest;
+        if (GVAR(outputToRPT) && {_output isNotEqualTo []}) then {
+            INFO(str _outputTest);
         };
         _output append _outputTest;
         TRACE_2("Appending to output",_output,_outputTest);

--- a/addons/autotest/functions/fnc_autotest.sqf
+++ b/addons/autotest/functions/fnc_autotest.sqf
@@ -13,6 +13,9 @@ private _output = [];
 
     private _outputTest = call compile _code;
     if (_outputTest isEqualType []) then {
+        if (_output isNotEqualTo []) then {
+            diag_log _outputTest;
+        };
         _output append _outputTest;
         TRACE_2("Appending to output",_output,_outputTest);
     };

--- a/addons/autotest/initSettings.sqf
+++ b/addons/autotest/initSettings.sqf
@@ -1,0 +1,7 @@
+[
+    QGVAR(outputToRPT),
+    "CHECKBOX",
+    ["Output Autotest Results to RPT","Logs all autotest results to the RPT file/"],
+    ["TMF", "Autotest"],
+    false
+] call CBA_fnc_addSetting;


### PR DESCRIPTION
I'm having an isse where the error message from a loadout check gets cut off by the dialog edge, so I can't actually see what the full problem is to fix it.

![9b762658cfa202cf566ddc00832e9dd7](https://user-images.githubusercontent.com/15274778/143309740-903421cc-6ca1-4cc5-9d29-1f58836f42bf.png)

This will just print each message to RPT, making it much easier for mission makers to debug longer errors.

Alternatives:
1. Make the dialog box wider, there is lots of room on either side to expand it
1. Allow error messages to be copied and pasted
1. Add a button that dumps errors to rpt when clicked, instead of all the time like in this PR.